### PR TITLE
[WIP]import cve-dates from RedHat Security

### DIFF
--- a/commands/fetchredhat.go
+++ b/commands/fetchredhat.go
@@ -1,0 +1,108 @@
+package commands
+
+import (
+	"context"
+	"flag"
+	"os"
+
+	"github.com/google/subcommands"
+	"github.com/k0kubun/pp"
+	c "github.com/kotakanbe/go-cve-dictionary/config"
+	log "github.com/kotakanbe/go-cve-dictionary/log"
+	"github.com/kotakanbe/go-cve-dictionary/redhat"
+	"github.com/kotakanbe/go-cve-dictionary/util"
+)
+
+// FetchRedHatCmd is Subcommand for fetch CVE information from RedHat Customer Portal.
+// https://www.redhat.com/security/data/metrics/
+type FetchRedHatCmd struct {
+	debug    bool
+	debugSQL bool
+	logDir   string
+
+	dbpath string
+	dbtype string
+
+	httpProxy string
+}
+
+// Name return subcommand name
+func (*FetchRedHatCmd) Name() string { return "fetch-redhat" }
+
+// Synopsis return synopsis
+func (*FetchRedHatCmd) Synopsis() string {
+	return "Fetch Vulnerability dictionary from RedHat Customer Portal"
+}
+
+// Usage return usage
+func (*FetchRedHatCmd) Usage() string {
+	return `fetchredhat:
+	fetchredhat
+		[-dbtype=mysql|sqlite3]
+		[-dbpath=$PWD/cve.sqlite3 or connection string]
+		[-http-proxy=http://192.168.0.1:8080]
+		[-debug]
+		[-debug-sql]
+		[-log-dir=/path/to/log]
+
+For the first time, run the blow command to fetch data for entire period. (It takes about 10 minutes)
+   $ for i in {2002..2016}; do go-cve-dictionary fetchnvd -years $i; done
+
+`
+}
+
+// SetFlags set flag
+func (p *FetchRedHatCmd) SetFlags(f *flag.FlagSet) {
+	f.BoolVar(&p.debug, "debug", false,
+		"debug mode")
+	f.BoolVar(&p.debugSQL, "debug-sql", false,
+		"SQL debug mode")
+
+	defaultLogDir := util.GetDefaultLogDir()
+	f.StringVar(&p.logDir, "log-dir", defaultLogDir, "/path/to/log")
+
+	pwd := os.Getenv("PWD")
+	f.StringVar(&p.dbpath, "dbpath", pwd+"/cve.sqlite3",
+		"/path/to/sqlite3 or SQL connection string")
+
+	f.StringVar(&p.dbtype, "dbtype", "sqlite3",
+		"Database type to store data in (sqlite3 or mysql supported)")
+
+	f.StringVar(
+		&p.httpProxy,
+		"http-proxy",
+		"",
+		"http://proxy-url:port (default: empty)",
+	)
+}
+
+// Execute execute
+func (p *FetchRedHatCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+	log.Initialize(p.logDir)
+
+	c.Conf.DebugSQL = p.debugSQL
+	c.Conf.Debug = p.debug
+	if c.Conf.Debug {
+		log.SetDebug()
+	}
+
+	c.Conf.DBPath = p.dbpath
+	c.Conf.DBType = p.dbtype
+	c.Conf.HTTPProxy = p.httpProxy
+
+	if !c.Conf.Validate() {
+		return subcommands.ExitUsageError
+	}
+
+	c, err := redhat.FetchFile()
+	if err != nil {
+		log.Error(err)
+		return subcommands.ExitFailure
+	}
+
+	cves := redhat.Parse(c)
+	for _, c := range cves {
+		pp.Println(c)
+	}
+	return subcommands.ExitSuccess
+}

--- a/commands/fetchredhat.go
+++ b/commands/fetchredhat.go
@@ -13,7 +13,7 @@ import (
 	"github.com/kotakanbe/go-cve-dictionary/util"
 )
 
-// FetchRedHatCmd is Subcommand for fetch CVE information from RedHat Customer Portal.
+// FetchRedHatCmd is Subcommand for fetch CVE information from RedHat Security.
 // https://www.redhat.com/security/data/metrics/
 type FetchRedHatCmd struct {
 	debug    bool
@@ -31,23 +31,19 @@ func (*FetchRedHatCmd) Name() string { return "fetch-redhat" }
 
 // Synopsis return synopsis
 func (*FetchRedHatCmd) Synopsis() string {
-	return "Fetch Vulnerability dictionary from RedHat Customer Portal"
+	return "Fetch Vulnerability DataBase from RedHat Security"
 }
 
 // Usage return usage
 func (*FetchRedHatCmd) Usage() string {
-	return `fetchredhat:
-	fetchredhat
+	return `fetch-redhat:
+	fetch-redhat
 		[-dbtype=mysql|sqlite3]
 		[-dbpath=$PWD/cve.sqlite3 or connection string]
 		[-http-proxy=http://192.168.0.1:8080]
 		[-debug]
 		[-debug-sql]
 		[-log-dir=/path/to/log]
-
-For the first time, run the blow command to fetch data for entire period. (It takes about 10 minutes)
-   $ for i in {2002..2016}; do go-cve-dictionary fetchnvd -years $i; done
-
 `
 }
 
@@ -113,6 +109,7 @@ func (p *FetchRedHatCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interf
 		log.Error(err)
 		return subcommands.ExitFailure
 	}
+
 	if err := db.InsertRedHat(cves); err != nil {
 		log.Error(err)
 		return subcommands.ExitFailure

--- a/commands/fetchredhat.go
+++ b/commands/fetchredhat.go
@@ -6,8 +6,8 @@ import (
 	"os"
 
 	"github.com/google/subcommands"
-	"github.com/k0kubun/pp"
 	c "github.com/kotakanbe/go-cve-dictionary/config"
+	"github.com/kotakanbe/go-cve-dictionary/db"
 	log "github.com/kotakanbe/go-cve-dictionary/log"
 	"github.com/kotakanbe/go-cve-dictionary/redhat"
 	"github.com/kotakanbe/go-cve-dictionary/util"
@@ -94,15 +94,28 @@ func (p *FetchRedHatCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interf
 		return subcommands.ExitUsageError
 	}
 
-	c, err := redhat.FetchFile()
+	content, err := redhat.FetchFile()
 	if err != nil {
 		log.Error(err)
 		return subcommands.ExitFailure
 	}
 
-	cves := redhat.Parse(c)
-	for _, c := range cves {
-		pp.Println(c)
+	cves := redhat.Parse(content)
+
+	log.Infof("Opening DB (%s).", c.Conf.DBType)
+	if err := db.OpenDB(); err != nil {
+		log.Error(err)
+		return subcommands.ExitFailure
+	}
+
+	log.Info("Migrating DB")
+	if err := db.MigrateDB(); err != nil {
+		log.Error(err)
+		return subcommands.ExitFailure
+	}
+	if err := db.InsertRedHat(cves); err != nil {
+		log.Error(err)
+		return subcommands.ExitFailure
 	}
 	return subcommands.ExitSuccess
 }

--- a/db/db.go
+++ b/db/db.go
@@ -699,20 +699,35 @@ func convertRedHat(entries []redhat.CveDates) (cves []models.CveDetail) {
 	return
 }
 
-//  insertIntoNvd inserts CveInformation into DB
+//  insertIntoRedHat inserts CveInformation into DB
 func insertIntoRedHat(cves []models.CveDetail) error {
 	refreshed := []string{}
 	tx := db.Begin()
+
+	// Delete all from red_hats
 	if err := tx.Unscoped().Delete(models.RedHat{}).Error; err != nil {
 		tx.Rollback()
 		return fmt.Errorf("Failed to delete from RedHat: %s", err)
 	}
 
 	for _, c := range cves {
-		if err := tx.Create(&c).Error; err != nil {
+		old := models.CveDetail{}
+		r := tx.Where(&models.CveDetail{CveID: c.CveID}).First(&old)
+		if r.RecordNotFound() || old.ID == 0 {
+			if err := tx.Create(&c).Error; err != nil {
+				tx.Rollback()
+				return fmt.Errorf("Failed to insert. cve: %s, err: %s",
+					pp.Sprintf("%v", c), err)
+			}
+			refreshed = append(refreshed, c.CveID)
+			continue
+		}
+
+		c.RedHat.CveDetailID = old.ID
+		if err := tx.Create(&c.RedHat).Error; err != nil {
 			tx.Rollback()
 			return fmt.Errorf("Failed to insert. cve: %s, err: %s",
-				pp.Sprintf("%v", c), err)
+				pp.Sprintf("%v", c.RedHat), err)
 		}
 		refreshed = append(refreshed, c.CveID)
 	}

--- a/db/db.go
+++ b/db/db.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cheggaaa/pb"
 	log "github.com/kotakanbe/go-cve-dictionary/log"
+	"github.com/kotakanbe/go-cve-dictionary/redhat"
 
 	"github.com/jinzhu/gorm"
 	"github.com/k0kubun/pp"
@@ -70,6 +71,7 @@ func MigrateDB() error {
 		&models.Nvd{},
 		&models.Reference{},
 		&models.Cpe{},
+		&models.RedHat{},
 	).Error; err != nil {
 		return fmt.Errorf("Failed to migrate. err: %s", err)
 	}
@@ -107,6 +109,10 @@ func MigrateDB() error {
 		AddIndex("idx_references_nvd_id", "nvd_id").Error; err != nil {
 		return fmt.Errorf(errMsg, err)
 	}
+	if err := db.Model(&models.RedHat{}).
+		AddIndex("idx_redhats_cve_detail_id", "cve_detail_id").Error; err != nil {
+		return fmt.Errorf(errMsg, err)
+	}
 
 	return nil
 }
@@ -134,6 +140,7 @@ func Get(cveID string, priorityDB ...*gorm.DB) models.CveDetail {
 				References: []models.Reference{},
 				Cpes:       []models.Cpe{},
 			},
+			RedHat: models.RedHat{},
 		}
 	}
 
@@ -174,6 +181,10 @@ func Get(cveID string, priorityDB ...*gorm.DB) models.CveDetail {
 			c.Nvd.Cpes = []models.Cpe{}
 		}
 	}
+
+	redhat := models.RedHat{}
+	conn.Model(&c).Related(&redhat, "RedHat")
+	c.RedHat = redhat
 
 	return c
 }
@@ -658,4 +669,54 @@ func insertIntoNvd(cves []models.CveDetail) error {
 	log.Infof("Refreshed %d Nvds.", len(refreshedNvds))
 	//  log.Debugf("%v", refreshedNvds)
 	return nil
+}
+
+// InsertRedHat inserts CveInformation into DB
+func InsertRedHat(entries []redhat.CveDates) error {
+	log.Info("Inserting CVEs...")
+
+	cves := convertRedHat(entries)
+	if err := insertIntoRedHat(cves); err != nil {
+		return err
+	}
+	return nil
+}
+
+//  // insertIntoNvd inserts CveInformation into DB
+func insertIntoRedHat(cves []models.CveDetail) error {
+	refreshed := []string{}
+	tx := db.Begin()
+	if err := tx.Unscoped().Delete(models.RedHat{}).Error; err != nil {
+		tx.Rollback()
+		return fmt.Errorf("Failed to delete from RedHat: %s", err)
+	}
+
+	for _, c := range cves {
+		if err := tx.Create(&c).Error; err != nil {
+			tx.Rollback()
+			return fmt.Errorf("Failed to insert. cve: %s, err: %s",
+				pp.Sprintf("%v", c), err)
+		}
+		refreshed = append(refreshed, c.CveID)
+	}
+	tx.Commit()
+	log.Infof("Refreshed %d records.", len(refreshed))
+	return nil
+}
+
+// convertRedHat converts RedHat structure(got from RedHat Security) to model
+func convertRedHat(entries []redhat.CveDates) (cves []models.CveDetail) {
+	for _, e := range entries {
+		cve := models.CveDetail{
+			CveID: e.CveID,
+			RedHat: models.RedHat{
+				Impact: e.Impact,
+				Source: e.Source,
+				Cvss2:  e.Cvss2,
+				Cvss3:  e.Cvss3,
+			},
+		}
+		cves = append(cves, cve)
+	}
+	return
 }

--- a/db/db.go
+++ b/db/db.go
@@ -682,7 +682,24 @@ func InsertRedHat(entries []redhat.CveDates) error {
 	return nil
 }
 
-//  // insertIntoNvd inserts CveInformation into DB
+// convertRedHat converts RedHat structure(got from RedHat Security) to model
+func convertRedHat(entries []redhat.CveDates) (cves []models.CveDetail) {
+	for _, e := range entries {
+		cve := models.CveDetail{
+			CveID: e.CveID,
+			RedHat: models.RedHat{
+				Impact: e.Impact,
+				Source: e.Source,
+				Cvss2:  e.Cvss2,
+				Cvss3:  e.Cvss3,
+			},
+		}
+		cves = append(cves, cve)
+	}
+	return
+}
+
+//  insertIntoNvd inserts CveInformation into DB
 func insertIntoRedHat(cves []models.CveDetail) error {
 	refreshed := []string{}
 	tx := db.Begin()
@@ -702,21 +719,4 @@ func insertIntoRedHat(cves []models.CveDetail) error {
 	tx.Commit()
 	log.Infof("Refreshed %d records.", len(refreshed))
 	return nil
-}
-
-// convertRedHat converts RedHat structure(got from RedHat Security) to model
-func convertRedHat(entries []redhat.CveDates) (cves []models.CveDetail) {
-	for _, e := range entries {
-		cve := models.CveDetail{
-			CveID: e.CveID,
-			RedHat: models.RedHat{
-				Impact: e.Impact,
-				Source: e.Source,
-				Cvss2:  e.Cvss2,
-				Cvss3:  e.Cvss3,
-			},
-		}
-		cves = append(cves, cve)
-	}
-	return
 }

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ func main() {
 	subcommands.Register(&commands.ServerCmd{}, "server")
 	subcommands.Register(&commands.FetchJvnCmd{}, "fetchjvn")
 	subcommands.Register(&commands.FetchNvdCmd{}, "fetchnvd")
+	subcommands.Register(&commands.FetchRedHatCmd{}, "fetch-redhat")
 
 	var v = flag.Bool("v", false, "Show version")
 

--- a/models/models.go
+++ b/models/models.go
@@ -27,9 +27,10 @@ type CveDetail struct {
 	gorm.Model `json:"-" xml:"-"`
 	CveInfoID  uint `json:"-" xml:"-"`
 
-	CveID string
-	Nvd   Nvd
-	Jvn   Jvn
+	CveID  string
+	Nvd    Nvd
+	Jvn    Jvn
+	RedHat RedHat
 }
 
 // CvssScore returns CVSS Score of the CVE
@@ -99,7 +100,7 @@ type Nvd struct {
 	CveDetailID uint `json:"-" xml:"-"`
 
 	// Increased size of summary to ensure we can fit arbitrary CVE content.
-	Summary               string `gorm:"size:4096"`
+	Summary string `gorm:"size:4096"`
 
 	Score                 float64 // 1 to 10
 	AccessVector          string
@@ -215,7 +216,7 @@ type Jvn struct {
 	CveDetailID uint `json:"-" xml:"-"`
 
 	Title   string
-	Summary string    `gorm:"size:8192"`
+	Summary string `gorm:"size:8192"`
 	JvnLink string
 	JvnID   string
 
@@ -326,5 +327,19 @@ type Reference struct {
 	NvdID      uint `json:"-" xml:"-"`
 
 	Source string
-	Link   string   `gorm:"size:512"`
+	Link   string `gorm:"size:512"`
+}
+
+// RedHat is a model of RedHat
+type RedHat struct {
+	//  gorm.Model  `json:"-" xml:"-"`
+	ID          uint `gorm:"primary_key" json:"-" xml:"-"`
+	CveDetailID uint `json:"-" xml:"-"`
+
+	Impact string
+	//  Public   string //
+	//  Reported string //
+	Source string
+	Cvss2  string
+	Cvss3  string
 }

--- a/redhat/redhat.go
+++ b/redhat/redhat.go
@@ -1,0 +1,76 @@
+package redhat
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	c "github.com/kotakanbe/go-cve-dictionary/config"
+	"github.com/parnurzeal/gorequest"
+)
+
+// CveDates cve dates
+// https://www.redhat.com/security/data/metrics/cve_dates.txt
+// ex.
+// CVE-2016-9589 impact=moderate,public=20170322,reported=20161214,source=customer,cvss2=5.0/AV:N/AC:L/Au:N/C:N/I:N/A:P,cvss3=7.5/CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+type CveDates struct {
+	CveID    string
+	Impact   string
+	Public   string
+	Reported string
+	Source   string
+	Cvss2    string
+	Cvss3    string
+}
+
+const url = "https://www.redhat.com/security/data/metrics/cve_dates.txt"
+
+// FetchFile fetches file
+func FetchFile() (contents string, err error) {
+	var body string
+	var errs []error
+	var resp *http.Response
+
+	resp, body, errs = gorequest.New().Proxy(c.Conf.HTTPProxy).Get(url).End()
+	if len(errs) > 0 || resp == nil || resp.StatusCode != 200 {
+		return "", fmt.Errorf(
+			"HTTP error. errs: %v, url: %s", errs, url)
+	}
+	return string(body), nil
+}
+
+var keys = []string{"impact", "public", "reported", "source", "cvss2", "cvss3"}
+
+// Parse parses the contents
+func Parse(contents string) (cves []CveDates) {
+	for _, line := range strings.Split(contents, "\n") {
+		if !strings.HasPrefix(line, "CVE-") {
+			continue
+		}
+		f := strings.Fields(line)
+		cve := CveDates{
+			CveID: f[0],
+		}
+		if 1 < len(f) {
+			for _, kv := range strings.Split(f[1], ",") {
+				ss := strings.Split(kv, "=")
+				switch ss[0] {
+				case "impact":
+					cve.Impact = ss[1]
+				case "public":
+					cve.Public = ss[1]
+				case "reported":
+					cve.Reported = ss[1]
+				case "source":
+					cve.Source = ss[1]
+				case "cvss2":
+					cve.Cvss2 = ss[1]
+				case "cvss3":
+					cve.Cvss3 = ss[1]
+				}
+			}
+		}
+		cves = append(cves, cve)
+	}
+	return
+}

--- a/redhat/redhat.go
+++ b/redhat/redhat.go
@@ -9,9 +9,9 @@ import (
 	"github.com/parnurzeal/gorequest"
 )
 
-// CveDates cve dates
+// CveDates is a struct of cve-dates data
 // https://www.redhat.com/security/data/metrics/cve_dates.txt
-// ex.
+// ex)
 // CVE-2016-9589 impact=moderate,public=20170322,reported=20161214,source=customer,cvss2=5.0/AV:N/AC:L/Au:N/C:N/I:N/A:P,cvss3=7.5/CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
 type CveDates struct {
 	CveID    string
@@ -39,9 +39,8 @@ func FetchFile() (contents string, err error) {
 	return string(body), nil
 }
 
-var keys = []string{"impact", "public", "reported", "source", "cvss2", "cvss3"}
-
 // Parse parses the contents
+// TODO test case
 func Parse(contents string) (cves []CveDates) {
 	for _, line := range strings.Split(contents, "\n") {
 		if !strings.HasPrefix(line, "CVE-") {


### PR DESCRIPTION
https://www.redhat.com/security/data/metrics/
https://www.redhat.com/security/data/metrics/cve_dates.txt

> CVE to date, CVE to severity, CVE to CVSS mapping
> 
> This data source maps CVE names to the dates the issues were first known to the public. This helps generate statistics based on "days of risk". This data source also captures the severity of the issues and how we found out about them (dates and sources). Although the dates may come from third-parties, the severity classifications are given by Red Hat Product Security and are specific to Red Hat, and will vary for other distributions and vendors. This file is updated here every one or two weeks (or by request, by contacting secalert@redhat.com):
