### PR TITLE
chore(linter): change linter from golint to revive

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.32
+          version: v1.42
           args: --timeout=10m
           
           # Optional: working directory, useful for monorepos

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,14 +1,44 @@
 name: golang-ci
 
 linters-settings:
-  errcheck:
+  revive:
+    # see https://github.com/mgechev/revive#available-rules for details.
+    ignore-generated-header: true
+    severity: warning
+    confidence: 0.8
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+      - name: if-return
+      - name: increment-decrement
+      - name: var-naming
+      - name: var-declaration
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+      - name: superfluous-else
+      - name: unused-parameter
+      - name: unreachable-code
+      - name: redefines-builtin-id
+  # errcheck:
     #exclude: /path/to/file.txt
 
 linters:
   disable-all: true
   enable:
     - goimports
-    - golint
+    - revive
     - govet
     - misspell
     - errcheck

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,7 @@ builds:
   goarch:
   - amd64
   main: .
-  ldflags: -s -w -X main.version={{.Version}} -X main.revision={{.Commit}}
+  ldflags: -s -w -X github.com/vulsio/go-cve-dictionary/config.Version={{.Version}} -X github.com/vulsio/go-cve-dictionary/config.Revision={{.Commit}}
   binary: go-cve-dictionary
 archives:
 - name_template: '{{ .Binary }}_{{.Version}}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'

--- a/.revive.toml
+++ b/.revive.toml
@@ -1,0 +1,30 @@
+ignoreGeneratedHeader = false
+severity = "warning"
+confidence = 0.8
+errorCode = 0
+warningCode = 0
+
+[rule.blank-imports]
+[rule.context-as-argument]
+[rule.context-keys-type]
+[rule.dot-imports]
+[rule.error-return]
+[rule.error-strings]
+[rule.error-naming]
+[rule.exported]
+[rule.if-return]
+[rule.increment-decrement]
+[rule.var-naming]
+[rule.var-declaration]
+[rule.package-comments]
+[rule.range]
+[rule.receiver-naming]
+[rule.time-naming]
+[rule.unexported-return]
+[rule.indent-error-flow]
+[rule.errorf]
+[rule.empty-block]
+[rule.superfluous-else]
+[rule.unused-parameter]
+[rule.unreachable-code]
+[rule.redefines-builtin-id]

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,8 +1,8 @@
 .PHONY: \
+	all \
 	build \
 	install \
-	all \
-	vendor \
+	lint \
 	vet \
 	fmt \
 	fmtcheck \
@@ -30,13 +30,17 @@ LDFLAGS := -X 'github.com/vulsio/go-cve-dictionary/config.Version=$(VERSION)' \
 GO := GO111MODULE=on go
 GO_OFF := GO111MODULE=off go
 
-all: build 
+all: build test
 
-build: main.go pretest fmt
+build: main.go
 	$(GO) build -ldflags "$(LDFLAGS)" -o go-cve-dictionary $<
 
 install: main.go 
 	$(GO) install -ldflags "$(LDFLAGS)"
+
+lint:
+	$(GO_OFF) get -u github.com/mgechev/revive
+	revive -config ./.revive.toml -formatter plain $(PKGS)
 
 vet:
 	echo $(PKGS) | xargs env $(GO) vet || exit;
@@ -50,7 +54,7 @@ mlint:
 fmtcheck:
 	$(foreach file,$(SRCS),gofmt -d $(file);)
 
-pretest: vet fmtcheck
+pretest: lint vet fmtcheck
 
 test: pretest
 	$(GO) test -cover -v ./... || exit;

--- a/commands/fetchjvn.go
+++ b/commands/fetchjvn.go
@@ -20,7 +20,7 @@ func init() {
 	fetchCmd.AddCommand(fetchJvnCmd)
 }
 
-func fetchJvn(cmd *cobra.Command, args []string) (err error) {
+func fetchJvn(_ *cobra.Command, _ []string) (err error) {
 	if err := log.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/commands/fetchnvd.go
+++ b/commands/fetchnvd.go
@@ -23,7 +23,7 @@ func init() {
 	_ = viper.BindPFlag("full", fetchNvdCmd.PersistentFlags().Lookup("full"))
 }
 
-func fetchNvd(cmd *cobra.Command, args []string) (err error) {
+func fetchNvd(_ *cobra.Command, _ []string) (err error) {
 	if err := log.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/commands/server.go
+++ b/commands/server.go
@@ -28,7 +28,7 @@ func init() {
 	_ = viper.BindPFlag("port", serverCmd.PersistentFlags().Lookup("port"))
 }
 
-func executeServer(cmd *cobra.Command, args []string) (err error) {
+func executeServer(_ *cobra.Command, _ []string) (err error) {
 	if err := log.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -45,7 +45,7 @@ func (r *RDBDriver) Name() string {
 }
 
 // OpenDB opens Database
-func (r *RDBDriver) OpenDB(dbType, dbPath string, debugSQL bool, option Option) (locked bool, err error) {
+func (r *RDBDriver) OpenDB(dbType, dbPath string, debugSQL bool, _ Option) (locked bool, err error) {
 	gormConfig := gorm.Config{
 		DisableForeignKeyConstraintWhenMigrating: true,
 		Logger: gormLogger.New(
@@ -427,10 +427,7 @@ func deleteJvn(tx *gorm.DB) error {
 	if err := tx.Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(models.JvnReference{}).Error; err != nil {
 		return err
 	}
-	if err := tx.Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(models.JvnCert{}).Error; err != nil {
-		return err
-	}
-	return nil
+	return tx.Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(models.JvnCert{}).Error
 }
 
 func insertJvn(tx *gorm.DB, cves []models.Jvn, batchSize int) error {
@@ -550,10 +547,7 @@ func deleteNvd(tx *gorm.DB) error {
 	if err := tx.Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(models.NvdReference{}).Error; err != nil {
 		return err
 	}
-	if err := tx.Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(models.NvdCert{}).Error; err != nil {
-		return err
-	}
-	return nil
+	return tx.Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(models.NvdCert{}).Error
 }
 
 func insertNvd(tx *gorm.DB, cves []models.Nvd, batchSize int) error {

--- a/db/redis.go
+++ b/db/redis.go
@@ -69,7 +69,7 @@ func (r *RedisDriver) Name() string {
 }
 
 // OpenDB opens Database
-func (r *RedisDriver) OpenDB(dbType, dbPath string, debugSQL bool, option Option) (locked bool, err error) {
+func (r *RedisDriver) OpenDB(dbType, dbPath string, _ bool, option Option) (locked bool, err error) {
 	if err = r.connectRedis(dbPath, option); err != nil {
 		err = xerrors.Errorf("Failed to open DB. dbtype: %s, dbpath: %s, err: %w", dbType, dbPath, err)
 	}


### PR DESCRIPTION
# What did you implement:
Change the linter to revive, since golint has been deprecated as follows.
> NOTE: Golint is deprecated and frozen. There's no drop-in replacement for it, but tools such as Staticcheck and go vet should be used instead.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
```console
$ make lint
$ golangci-lint run -c .golangci.yml
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

