### PR TITLE
fix(db): change fetchmeta insert order

### DIFF
--- a/commands/fetchjvn.go
+++ b/commands/fetchjvn.go
@@ -43,14 +43,14 @@ func fetchJvn(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.New("Failed to Insert CVEs into DB. SchemaVersion is old")
 	}
 
-	log.Infof("Inserting JVN into DB (%s).", driver.Name())
-	if err := driver.InsertJvn(); err != nil {
-		log.Fatalf("Failed to insert. dbpath: %s, err: %s", viper.GetString("dbpath"), err)
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		log.Errorf("Failed to upsert FetchMeta to DB. err: %s", err)
 		return err
 	}
 
-	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
-		log.Errorf("Failed to upsert FetchMeta to DB. err: %s", err)
+	log.Infof("Inserting JVN into DB (%s).", driver.Name())
+	if err := driver.InsertJvn(); err != nil {
+		log.Fatalf("Failed to insert. dbpath: %s, err: %s", viper.GetString("dbpath"), err)
 		return err
 	}
 

--- a/commands/fetchnvd.go
+++ b/commands/fetchnvd.go
@@ -46,14 +46,14 @@ func fetchNvd(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.New("Failed to Insert CVEs into DB. SchemaVersion is old")
 	}
 
-	log.Infof("Inserting NVD into DB (%s).", driver.Name())
-	if err := driver.InsertNvd(); err != nil {
-		log.Errorf("Failed to insert. dbpath: %s, err: %s", viper.GetString("dbpath"), err)
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		log.Errorf("Failed to upsert FetchMeta to DB. err: %s", err)
 		return err
 	}
 
-	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
-		log.Errorf("Failed to upsert FetchMeta to DB. err: %s", err)
+	log.Infof("Inserting NVD into DB (%s).", driver.Name())
+	if err := driver.InsertNvd(); err != nil {
+		log.Errorf("Failed to insert. dbpath: %s, err: %s", viper.GetString("dbpath"), err)
 		return err
 	}
 


### PR DESCRIPTION
# What did you implement:
If an error occurs during the first fetch, it is required to clean the DB during the second Insert. 
The old data can be deleted when updating between the same schema versions.
To avoid this problem, insert FetchMeta first.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?


# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES 

# Reference

