### PR TITLE
refactor(db): return pipeline in Redis GetMulti and do not judge ErrRecordNotFound unnecessarily

### DIFF
--- a/db/rdb.go
+++ b/db/rdb.go
@@ -209,7 +209,7 @@ func (r *RDBDriver) Get(cveID string) (*models.CveDetail, error) {
 		Preload("Cpes").
 		Preload("References").
 		Preload("Certs").
-		Find(&detail.Nvds).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		Find(&detail.Nvds).Error; err != nil {
 		return nil, xerrors.Errorf("Failed to fill Nvd. Nvd{CveID: %s} err: %w", cveID, err)
 	}
 
@@ -217,7 +217,7 @@ func (r *RDBDriver) Get(cveID string) (*models.CveDetail, error) {
 		for j := range detail.Nvds[i].Cpes {
 			if err := r.conn.
 				Where(&models.NvdEnvCpe{NvdCpeID: uint(detail.Nvds[i].Cpes[j].ID)}).
-				Find(&detail.Nvds[i].Cpes[j].EnvCpes).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+				Find(&detail.Nvds[i].Cpes[j].EnvCpes).Error; err != nil {
 				return nil, xerrors.Errorf("Failed to fill Nvd EnvCpes. Nvd{CveID: %s} Cpes:{NvdCpeID: %d} err: %w", cveID, uint(detail.Nvds[i].Cpes[j].ID), err)
 			}
 		}
@@ -230,7 +230,7 @@ func (r *RDBDriver) Get(cveID string) (*models.CveDetail, error) {
 		Preload("Cpes").
 		Preload("References").
 		Preload("Certs").
-		Find(&detail.Jvns).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		Find(&detail.Jvns).Error; err != nil {
 		return nil, xerrors.Errorf("Failed to fill Jvn. Jvn{CveID: %s} err: %w", cveID, err)
 	}
 
@@ -252,7 +252,7 @@ func (r *RDBDriver) getCveIDsByPartVendorProduct(uri string) ([]string, error) {
 		Select("nvds.cve_id").
 		Joins("JOIN nvd_cpes ON nvd_cpes.nvd_id = nvds.id").
 		Where("nvd_cpes.part = ? AND nvd_cpes.vendor = ? AND nvd_cpes.product = ?", part, vendor, product).
-		Find(&nvds).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		Find(&nvds).Error; err != nil {
 		return nil, err
 	}
 
@@ -261,7 +261,7 @@ func (r *RDBDriver) getCveIDsByPartVendorProduct(uri string) ([]string, error) {
 		Select("jvns.cve_id").
 		Joins("JOIN jvn_cpes ON jvn_cpes.jvn_id = jvns.id").
 		Where("jvn_cpes.part = ? AND jvn_cpes.vendor = ? AND jvn_cpes.product = ?", part, vendor, product).
-		Find(&jvns).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		Find(&jvns).Error; err != nil {
 		return nil, err
 	}
 
@@ -346,9 +346,6 @@ func (r *RDBDriver) GetByCpeURI(uri string) ([]models.CveDetail, error) {
 func (r *RDBDriver) CountJvn() (int, error) {
 	var count int64
 	if err := r.conn.Model(&models.Jvn{}).Count(&count).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return 0, nil
-		}
 		return 0, err
 	}
 	return int(count), nil
@@ -463,9 +460,6 @@ func insertJvn(tx *gorm.DB, cves []models.Jvn, batchSize int) error {
 func (r *RDBDriver) CountNvd() (int, error) {
 	var count int64
 	if err := r.conn.Model(&models.Nvd{}).Count(&count).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return 0, nil
-		}
 		return 0, err
 	}
 	return int(count), nil

--- a/db/redis.go
+++ b/db/redis.go
@@ -165,7 +165,14 @@ func (r *RedisDriver) Get(cveID string) (*models.CveDetail, error) {
 	if err != nil {
 		return nil, xerrors.Errorf("Failed to HGetAll. err: %w", err)
 	}
+	detail, err := convertToCveDetail(cveID, results)
+	if err != nil {
+		return nil, xerrors.Errorf("Failed to convertToCveDetail. err: %w", err)
+	}
+	return &detail, nil
+}
 
+func convertToCveDetail(cveID string, results map[string]string) (models.CveDetail, error) {
 	detail := models.CveDetail{
 		CveID: cveID,
 		Nvds:  []models.Nvd{},
@@ -175,7 +182,7 @@ func (r *RedisDriver) Get(cveID string) (*models.CveDetail, error) {
 	if jsonStr, ok := results[models.NvdType]; ok {
 		var nvd models.Nvd
 		if err := json.Unmarshal([]byte(jsonStr), &nvd); err != nil {
-			return nil, xerrors.Errorf("Failed to Unmarshal JSON. err: %w", err)
+			return models.CveDetail{}, xerrors.Errorf("Failed to Unmarshal JSON. err: %w", err)
 		}
 		detail.Nvds = append(detail.Nvds, nvd)
 		delete(results, models.NvdType)
@@ -183,30 +190,46 @@ func (r *RedisDriver) Get(cveID string) (*models.CveDetail, error) {
 
 	for field, jsonStr := range results {
 		if !strings.HasPrefix(field, "JVNDB-") {
-			log.Warnf("field(%s) obtained by CVEID(%s) is not in JVN format", field, cveID)
+			log.Warnf("field(%s) obtained by %s is not in JVN format", field, cveID)
 			continue
 		}
 
 		var jvn models.Jvn
 		if err := json.Unmarshal([]byte(jsonStr), &jvn); err != nil {
-			return nil, xerrors.Errorf("Failed to Unmarshal JSON. err: %w", err)
+			return models.CveDetail{}, xerrors.Errorf("Failed to Unmarshal JSON. err: %w", err)
 		}
 		detail.Jvns = append(detail.Jvns, jvn)
 	}
 
-	return &detail, nil
+	return detail, nil
 }
 
 // GetMulti Select Cves information from DB.
 func (r *RedisDriver) GetMulti(cveIDs []string) (map[string]models.CveDetail, error) {
-	cveDetails := map[string]models.CveDetail{}
+	ctx := context.Background()
+
+	m := map[string]*redis.StringStringMapCmd{}
+	pipe := r.conn.Pipeline()
 	for _, cveID := range cveIDs {
-		detail, err := r.Get(cveID)
-		if err != nil {
-			return nil, xerrors.Errorf("Failed to Get cve json. err : %w", err)
-		}
-		cveDetails[cveID] = *detail
+		m[cveID] = pipe.HGetAll(ctx, fmt.Sprintf(cveKeyFormat, cveID))
 	}
+	if _, err := pipe.Exec(ctx); err != nil {
+		return nil, xerrors.Errorf("Failed to exec pipeline. err: %w", err)
+	}
+
+	cveDetails := map[string]models.CveDetail{}
+	for cveID, cmd := range m {
+		results, err := cmd.Result()
+		if err != nil {
+			return nil, xerrors.Errorf("Failed to HGetAll. err: %w", err)
+		}
+		detail, err := convertToCveDetail(cveID, results)
+		if err != nil {
+			return nil, xerrors.Errorf("Failed to convertToCveDetail. err: %w", err)
+		}
+		cveDetails[cveID] = detail
+	}
+
 	return cveDetails, nil
 }
 
@@ -223,26 +246,27 @@ func (r *RedisDriver) GetCveIDsByCpeURI(uri string) ([]string, []string, error) 
 		return nil, nil, xerrors.Errorf("Failed to SMembers. err: %w", err)
 	}
 
+	cveDetails, err := r.GetMulti(cveIDs)
+	if err != nil {
+		return nil, nil, xerrors.Errorf("Failed to GetMulti. err: %w", err)
+	}
+
 	nvdCveIDs := []string{}
 	jvnCveIDs := []string{}
-	for _, cveID := range cveIDs {
-		d, err := r.Get(cveID)
-		if err != nil {
+	for _, detail := range cveDetails {
+		if err := filterCveDetailByCpeURI(uri, &detail); err != nil {
 			return nil, nil, err
 		}
-		if err := filterCveDetailByCpeURI(uri, d); err != nil {
-			return nil, nil, err
-		}
-		nvdMatch, jvnMatch, err := matchCpe(uri, d)
+		nvdMatch, jvnMatch, err := matchCpe(uri, &detail)
 		if err != nil {
-			log.Warnf("Failed to compare the version:%s %s %#v", err, uri, d)
+			log.Warnf("Failed to compare the version:%s %s %#v", err, uri, &detail)
 			// continue matching
 			continue
 		}
 		if nvdMatch {
-			nvdCveIDs = append(nvdCveIDs, d.CveID)
+			nvdCveIDs = append(nvdCveIDs, detail.CveID)
 		} else if jvnMatch {
-			jvnCveIDs = append(jvnCveIDs, d.CveID)
+			jvnCveIDs = append(jvnCveIDs, detail.CveID)
 		}
 	}
 
@@ -262,17 +286,18 @@ func (r *RedisDriver) GetByCpeURI(uri string) ([]models.CveDetail, error) {
 		return nil, xerrors.Errorf("Failed to SMembers. err: %w", err)
 	}
 
+	cveDetails, err := r.GetMulti(cveIDs)
+	if err != nil {
+		return nil, xerrors.Errorf("Failed to GetMulti. err: %w", err)
+	}
+
 	details := []models.CveDetail{}
-	for _, cveID := range cveIDs {
-		d, err := r.Get(cveID)
-		if err != nil {
+	for _, detail := range cveDetails {
+		if err := filterCveDetailByCpeURI(uri, &detail); err != nil {
 			return nil, err
 		}
-		if err := filterCveDetailByCpeURI(uri, d); err != nil {
-			return nil, err
-		}
-		if len(d.Nvds) > 0 || len(d.Jvns) > 0 {
-			details = append(details, *d)
+		if len(detail.Nvds) > 0 || len(detail.Jvns) > 0 {
+			details = append(details, detail)
 		}
 	}
 

--- a/db/redis.go
+++ b/db/redis.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cheggaaa/pb/v3"
@@ -180,7 +181,12 @@ func (r *RedisDriver) Get(cveID string) (*models.CveDetail, error) {
 		delete(results, models.NvdType)
 	}
 
-	for _, jsonStr := range results {
+	for field, jsonStr := range results {
+		if !strings.HasPrefix(field, "JVNDB-") {
+			log.Warnf("field(%s) obtained by CVEID(%s) is not in JVN format", field, cveID)
+			continue
+		}
+
 		var jvn models.Jvn
 		if err := json.Unmarshal([]byte(jsonStr), &jvn); err != nil {
 			return nil, xerrors.Errorf("Failed to Unmarshal JSON. err: %w", err)

--- a/fetcher/nvd/nvd.go
+++ b/fetcher/nvd/nvd.go
@@ -3,7 +3,6 @@ package nvd
 import (
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"runtime"
 	"strconv"
 	"strings"
@@ -47,8 +46,6 @@ func FetchConvert(uniqCve map[string]map[string]models.Nvd, years []string) erro
 			return xerrors.Errorf("Failed to convert. err: %w", err)
 		}
 		distributeCvesByYear(uniqCve, cves)
-
-		time.Sleep(time.Duration(rand.Intn(1000)) * time.Microsecond)
 	}
 	return nil
 }


### PR DESCRIPTION
# What did you implement:
Use the pipeline in GetMulti in Redis, and use GetMulti as much as possible when searching CPE.
Also, do not unnecessarily judge ErrRecordNotFound in the RDB.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
```console
$ make clean-integration && make build-integration
$ make fetch-rdb && make fetch-redis
$ make diff-server-rdb && make diff-server-redis && make diff-server-rdb-redis
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

