### PR TITLE
breaking-change(redis): deprecated expire option

### DIFF
--- a/commands/fetch.go
+++ b/commands/fetch.go
@@ -16,7 +16,4 @@ func init() {
 
 	fetchCmd.PersistentFlags().Int("batch-size", 5, "The number of batch size to insert.")
 	_ = viper.BindPFlag("batch-size", fetchCmd.PersistentFlags().Lookup("batch-size"))
-
-	fetchCmd.PersistentFlags().Uint("expire", 0, "timeout to set for Redis keys in seconds. If set to 0, the key is persistent.")
-	_ = viper.BindPFlag("expire", fetchCmd.PersistentFlags().Lookup("expire"))
 }

--- a/db/redis.go
+++ b/db/redis.go
@@ -377,11 +377,9 @@ func (r *RedisDriver) InsertJvn() error {
 					return xerrors.Errorf("Failed to marshal json. err: %w", err)
 				}
 
-				cveKey := fmt.Sprintf(cveKeyFormat, cve.CveID)
-				if err := pipe.HSet(ctx, cveKey, cve.JvnID, string(jn)).Err(); err != nil {
+				if err := pipe.HSet(ctx, fmt.Sprintf(cveKeyFormat, cve.CveID), cve.JvnID, string(jn)).Err(); err != nil {
 					return xerrors.Errorf("Failed to HSet CVE JSON. err: %w", err)
 				}
-
 				if _, ok := newDeps[cve.JvnID]; !ok {
 					newDeps[cve.JvnID] = map[string]map[string]struct{}{}
 				}
@@ -391,11 +389,9 @@ func (r *RedisDriver) InsertJvn() error {
 
 				for _, cpe := range cve.Cpes {
 					cpePartVendorProductStr := fmt.Sprintf("%s#%s#%s", cpe.Part, cpe.Vendor, cpe.Product)
-					cpeKey := fmt.Sprintf(cpeKeyFormat, cpePartVendorProductStr)
-					if err := pipe.SAdd(ctx, cpeKey, cve.CveID).Err(); err != nil {
+					if err := pipe.SAdd(ctx, fmt.Sprintf(cpeKeyFormat, cpePartVendorProductStr), cve.CveID).Err(); err != nil {
 						return xerrors.Errorf("Failed to SAdd CPE key. err: %w", err)
 					}
-
 					newDeps[cve.JvnID][cve.CveID][cpePartVendorProductStr] = struct{}{}
 					if _, ok := oldDeps[cve.JvnID]; ok {
 						if _, ok := oldDeps[cve.JvnID][cve.CveID]; ok {
@@ -429,7 +425,6 @@ func (r *RedisDriver) InsertJvn() error {
 					return xerrors.Errorf("Failed to SRem. err: %w", err)
 				}
 			}
-
 			if _, ok := newDeps[jvnID]; !ok {
 				if _, ok := newDeps[jvnID][cveID]; !ok {
 					if err := pipe.HDel(ctx, fmt.Sprintf(cveKeyFormat, cveID), jvnID).Err(); err != nil {
@@ -526,22 +521,18 @@ func (r *RedisDriver) InsertNvd() error {
 					return xerrors.Errorf("Failed to marshal json. err: %w", err)
 				}
 
-				cveKey := fmt.Sprintf(cveKeyFormat, cve.CveID)
-				if err := pipe.HSet(ctx, cveKey, models.NvdType, string(jn)).Err(); err != nil {
+				if err := pipe.HSet(ctx, fmt.Sprintf(cveKeyFormat, cve.CveID), models.NvdType, string(jn)).Err(); err != nil {
 					return xerrors.Errorf("Failed to HSet CVE JSON. err: %w", err)
 				}
-
 				if _, ok := newDeps[cve.CveID]; !ok {
 					newDeps[cve.CveID] = map[string]struct{}{}
 				}
 
 				for _, cpe := range cve.Cpes {
 					cpePartVendorProductStr := fmt.Sprintf("%s#%s#%s", cpe.Part, cpe.Vendor, cpe.Product)
-					cpeKey := fmt.Sprintf(cpeKeyFormat, cpePartVendorProductStr)
-					if err := pipe.SAdd(ctx, cpeKey, cve.CveID).Err(); err != nil {
+					if err := pipe.SAdd(ctx, fmt.Sprintf(cpeKeyFormat, cpePartVendorProductStr), cve.CveID).Err(); err != nil {
 						return xerrors.Errorf("Failed to SAdd CPE key. err: %w", err)
 					}
-
 					newDeps[cve.CveID][cpePartVendorProductStr] = struct{}{}
 					if _, ok := oldDeps[cve.CveID]; ok {
 						delete(oldDeps[cve.CveID], cpePartVendorProductStr)
@@ -569,7 +560,6 @@ func (r *RedisDriver) InsertNvd() error {
 				return xerrors.Errorf("Failed to SRem. err: %w", err)
 			}
 		}
-
 		if _, ok := newDeps[cveID]; !ok {
 			if err := pipe.HDel(ctx, fmt.Sprintf(cveKeyFormat, cveID), models.NvdType).Err(); err != nil {
 				return xerrors.Errorf("Failed to HDel. err: %w", err)

--- a/db/redis.go
+++ b/db/redis.go
@@ -326,7 +326,6 @@ func (r *RedisDriver) CountJvn() (int, error) {
 // InsertJvn insert items fetched from JVN.
 func (r *RedisDriver) InsertJvn() error {
 	ctx := context.Background()
-	expire := viper.GetUint("expire")
 	batchSize := viper.GetInt("batch-size")
 	if batchSize < 1 {
 		return fmt.Errorf("Failed to set batch-size. err: batch-size option is not set properly")
@@ -382,15 +381,6 @@ func (r *RedisDriver) InsertJvn() error {
 				if err := pipe.HSet(ctx, cveKey, cve.JvnID, string(jn)).Err(); err != nil {
 					return xerrors.Errorf("Failed to HSet CVE JSON. err: %w", err)
 				}
-				if expire > 0 {
-					if err := pipe.Expire(ctx, cveKey, time.Duration(expire*uint(time.Second))).Err(); err != nil {
-						return xerrors.Errorf("Failed to set Expire to Key. err: %w", err)
-					}
-				} else {
-					if err := pipe.Persist(ctx, cveKey).Err(); err != nil {
-						return xerrors.Errorf("Failed to remove the existing timeout on Key. err: %w", err)
-					}
-				}
 
 				if _, ok := newDeps[cve.JvnID]; !ok {
 					newDeps[cve.JvnID] = map[string]map[string]struct{}{}
@@ -404,15 +394,6 @@ func (r *RedisDriver) InsertJvn() error {
 					cpeKey := fmt.Sprintf(cpeKeyFormat, cpePartVendorProductStr)
 					if err := pipe.SAdd(ctx, cpeKey, cve.CveID).Err(); err != nil {
 						return xerrors.Errorf("Failed to SAdd CPE key. err: %w", err)
-					}
-					if expire > 0 {
-						if err := pipe.Expire(ctx, cpeKey, time.Duration(expire*uint(time.Second))).Err(); err != nil {
-							return xerrors.Errorf("Failed to set Expire to Key. err: %w", err)
-						}
-					} else {
-						if err := pipe.Persist(ctx, cpeKey).Err(); err != nil {
-							return xerrors.Errorf("Failed to remove the existing timeout on Key. err: %w", err)
-						}
 					}
 
 					newDeps[cve.JvnID][cve.CveID][cpePartVendorProductStr] = struct{}{}
@@ -465,15 +446,6 @@ func (r *RedisDriver) InsertJvn() error {
 	if err := pipe.HSet(ctx, depKey, models.JvnType, string(newDepsJSON)).Err(); err != nil {
 		return xerrors.Errorf("Failed to Set depkey. err: %w", err)
 	}
-	if expire > 0 {
-		if err := pipe.Expire(ctx, depKey, time.Duration(expire*uint(time.Second))).Err(); err != nil {
-			return xerrors.Errorf("Failed to set Expire to Key. err: %w", err)
-		}
-	} else {
-		if err := pipe.Persist(ctx, depKey).Err(); err != nil {
-			return xerrors.Errorf("Failed to remove the existing timeout on Key. err: %w", err)
-		}
-	}
 	if _, err = pipe.Exec(ctx); err != nil {
 		return xerrors.Errorf("Failed to exec pipeline. err: %w", err)
 	}
@@ -503,7 +475,6 @@ func (r *RedisDriver) CountNvd() (int, error) {
 // InsertNvd Cve information from DB.
 func (r *RedisDriver) InsertNvd() error {
 	ctx := context.Background()
-	expire := viper.GetUint("expire")
 	batchSize := viper.GetInt("batch-size")
 	if batchSize < 1 {
 		return fmt.Errorf("Failed to set batch-size. err: batch-size option is not set properly")
@@ -559,15 +530,6 @@ func (r *RedisDriver) InsertNvd() error {
 				if err := pipe.HSet(ctx, cveKey, models.NvdType, string(jn)).Err(); err != nil {
 					return xerrors.Errorf("Failed to HSet CVE JSON. err: %w", err)
 				}
-				if expire > 0 {
-					if err := pipe.Expire(ctx, cveKey, time.Duration(expire*uint(time.Second))).Err(); err != nil {
-						return xerrors.Errorf("Failed to set Expire to Key. err: %w", err)
-					}
-				} else {
-					if err := pipe.Persist(ctx, cveKey).Err(); err != nil {
-						return xerrors.Errorf("Failed to remove the existing timeout on Key. err: %w", err)
-					}
-				}
 
 				if _, ok := newDeps[cve.CveID]; !ok {
 					newDeps[cve.CveID] = map[string]struct{}{}
@@ -578,15 +540,6 @@ func (r *RedisDriver) InsertNvd() error {
 					cpeKey := fmt.Sprintf(cpeKeyFormat, cpePartVendorProductStr)
 					if err := pipe.SAdd(ctx, cpeKey, cve.CveID).Err(); err != nil {
 						return xerrors.Errorf("Failed to SAdd CPE key. err: %w", err)
-					}
-					if expire > 0 {
-						if err := pipe.Expire(ctx, cpeKey, time.Duration(expire*uint(time.Second))).Err(); err != nil {
-							return xerrors.Errorf("Failed to set Expire to Key. err: %w", err)
-						}
-					} else {
-						if err := pipe.Persist(ctx, cpeKey).Err(); err != nil {
-							return xerrors.Errorf("Failed to remove the existing timeout on Key. err: %w", err)
-						}
 					}
 
 					newDeps[cve.CveID][cpePartVendorProductStr] = struct{}{}
@@ -629,15 +582,6 @@ func (r *RedisDriver) InsertNvd() error {
 	}
 	if err := pipe.HSet(ctx, depKey, models.NvdType, string(newDepsJSON)).Err(); err != nil {
 		return xerrors.Errorf("Failed to HSet depkey. err: %w", err)
-	}
-	if expire > 0 {
-		if err := pipe.Expire(ctx, depKey, time.Duration(expire*uint(time.Second))).Err(); err != nil {
-			return xerrors.Errorf("Failed to set Expire to Key. err: %w", err)
-		}
-	} else {
-		if err := pipe.Persist(ctx, depKey).Err(); err != nil {
-			return xerrors.Errorf("Failed to remove the existing timeout on Key. err: %w", err)
-		}
 	}
 	if _, err = pipe.Exec(ctx); err != nil {
 		return xerrors.Errorf("Failed to exec pipeline. err: %w", err)


### PR DESCRIPTION
# What did you implement:
Expire was introduced to ensure safe operation in Redis, but since expire can only be set per key, it is not very useful for Sets and Hash.
Therefore, if there is any old content in each fetch, it will be deleted.

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?


# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  

# Reference

