### PR TITLE
fix(redis): pipe cannot take err except for pipe.Exec

### DIFF
--- a/db/redis.go
+++ b/db/redis.go
@@ -380,9 +380,7 @@ func (r *RedisDriver) InsertJvn() error {
 					return xerrors.Errorf("Failed to marshal json. err: %w", err)
 				}
 
-				if err := pipe.HSet(ctx, fmt.Sprintf(cveKeyFormat, cve.CveID), cve.JvnID, string(jn)).Err(); err != nil {
-					return xerrors.Errorf("Failed to HSet CVE JSON. err: %w", err)
-				}
+				_ = pipe.HSet(ctx, fmt.Sprintf(cveKeyFormat, cve.CveID), cve.JvnID, string(jn))
 				if _, ok := newDeps[cve.JvnID]; !ok {
 					newDeps[cve.JvnID] = map[string]map[string]struct{}{}
 				}
@@ -392,9 +390,7 @@ func (r *RedisDriver) InsertJvn() error {
 
 				for _, cpe := range cve.Cpes {
 					cpePartVendorProductStr := fmt.Sprintf("%s#%s#%s", cpe.Part, cpe.Vendor, cpe.Product)
-					if err := pipe.SAdd(ctx, fmt.Sprintf(cpeKeyFormat, cpePartVendorProductStr), cve.CveID).Err(); err != nil {
-						return xerrors.Errorf("Failed to SAdd CPE key. err: %w", err)
-					}
+					_ = pipe.SAdd(ctx, fmt.Sprintf(cpeKeyFormat, cpePartVendorProductStr), cve.CveID)
 					newDeps[cve.JvnID][cve.CveID][cpePartVendorProductStr] = struct{}{}
 					if _, ok := oldDeps[cve.JvnID]; ok {
 						if _, ok := oldDeps[cve.JvnID][cve.CveID]; ok {
@@ -424,15 +420,11 @@ func (r *RedisDriver) InsertJvn() error {
 	for jvnID, cves := range oldDeps {
 		for cveID, cpes := range cves {
 			for cpePartVendorProductStr := range cpes {
-				if err := pipe.SRem(ctx, fmt.Sprintf(cpeKeyFormat, cpePartVendorProductStr), cveID).Err(); err != nil {
-					return xerrors.Errorf("Failed to SRem. err: %w", err)
-				}
+				_ = pipe.SRem(ctx, fmt.Sprintf(cpeKeyFormat, cpePartVendorProductStr), cveID)
 			}
 			if _, ok := newDeps[jvnID]; !ok {
 				if _, ok := newDeps[jvnID][cveID]; !ok {
-					if err := pipe.HDel(ctx, fmt.Sprintf(cveKeyFormat, cveID), jvnID).Err(); err != nil {
-						return xerrors.Errorf("Failed to HDel. err: %w", err)
-					}
+					_ = pipe.HDel(ctx, fmt.Sprintf(cveKeyFormat, cveID), jvnID)
 				}
 			}
 		}
@@ -441,9 +433,7 @@ func (r *RedisDriver) InsertJvn() error {
 	if err != nil {
 		return xerrors.Errorf("Failed to Marshal JSON. err: %w", err)
 	}
-	if err := pipe.HSet(ctx, depKey, models.JvnType, string(newDepsJSON)).Err(); err != nil {
-		return xerrors.Errorf("Failed to Set depkey. err: %w", err)
-	}
+	_ = pipe.HSet(ctx, depKey, models.JvnType, string(newDepsJSON))
 	if _, err = pipe.Exec(ctx); err != nil {
 		return xerrors.Errorf("Failed to exec pipeline. err: %w", err)
 	}
@@ -524,18 +514,14 @@ func (r *RedisDriver) InsertNvd() error {
 					return xerrors.Errorf("Failed to marshal json. err: %w", err)
 				}
 
-				if err := pipe.HSet(ctx, fmt.Sprintf(cveKeyFormat, cve.CveID), models.NvdType, string(jn)).Err(); err != nil {
-					return xerrors.Errorf("Failed to HSet CVE JSON. err: %w", err)
-				}
+				_ = pipe.HSet(ctx, fmt.Sprintf(cveKeyFormat, cve.CveID), models.NvdType, string(jn))
 				if _, ok := newDeps[cve.CveID]; !ok {
 					newDeps[cve.CveID] = map[string]struct{}{}
 				}
 
 				for _, cpe := range cve.Cpes {
 					cpePartVendorProductStr := fmt.Sprintf("%s#%s#%s", cpe.Part, cpe.Vendor, cpe.Product)
-					if err := pipe.SAdd(ctx, fmt.Sprintf(cpeKeyFormat, cpePartVendorProductStr), cve.CveID).Err(); err != nil {
-						return xerrors.Errorf("Failed to SAdd CPE key. err: %w", err)
-					}
+					_ = pipe.SAdd(ctx, fmt.Sprintf(cpeKeyFormat, cpePartVendorProductStr), cve.CveID)
 					newDeps[cve.CveID][cpePartVendorProductStr] = struct{}{}
 					if _, ok := oldDeps[cve.CveID]; ok {
 						delete(oldDeps[cve.CveID], cpePartVendorProductStr)
@@ -559,23 +545,17 @@ func (r *RedisDriver) InsertNvd() error {
 	pipe := r.conn.Pipeline()
 	for cveID, cpes := range oldDeps {
 		for cpePartVendorProductStr := range cpes {
-			if err := pipe.SRem(ctx, fmt.Sprintf(cpeKeyFormat, cpePartVendorProductStr), cveID).Err(); err != nil {
-				return xerrors.Errorf("Failed to SRem. err: %w", err)
-			}
+			_ = pipe.SRem(ctx, fmt.Sprintf(cpeKeyFormat, cpePartVendorProductStr), cveID)
 		}
 		if _, ok := newDeps[cveID]; !ok {
-			if err := pipe.HDel(ctx, fmt.Sprintf(cveKeyFormat, cveID), models.NvdType).Err(); err != nil {
-				return xerrors.Errorf("Failed to HDel. err: %w", err)
-			}
+			_ = pipe.HDel(ctx, fmt.Sprintf(cveKeyFormat, cveID), models.NvdType)
 		}
 	}
 	newDepsJSON, err := json.Marshal(newDeps)
 	if err != nil {
 		return xerrors.Errorf("Failed to Marshal JSON. err: %w", err)
 	}
-	if err := pipe.HSet(ctx, depKey, models.NvdType, string(newDepsJSON)).Err(); err != nil {
-		return xerrors.Errorf("Failed to HSet depkey. err: %w", err)
-	}
+	_ = pipe.HSet(ctx, depKey, models.NvdType, string(newDepsJSON))
 	if _, err = pipe.Exec(ctx); err != nil {
 		return xerrors.Errorf("Failed to exec pipeline. err: %w", err)
 	}


### PR DESCRIPTION
# What did you implement:
Since pipe can't get err except for pipe.Exec, I modified the code.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

