### PR TITLE
fix(fetcher/jvn): not register invalid CVE-ID

### DIFF
--- a/fetcher/jvn/jvn.go
+++ b/fetcher/jvn/jvn.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -406,12 +407,17 @@ func parseJvnTime(strtime string) (t time.Time, err error) {
 	return
 }
 
+var cveIDPattern = regexp.MustCompile(`^CVE-[0-9]{4}-[0-9]{4,}$`)
+
 func getCveIDs(item Item) []string {
 	cveIDsMap := map[string]bool{}
 	for _, ref := range item.References {
 		switch ref.Source {
 		case "NVD", "CVE":
-			cveIDsMap[ref.ID] = true
+			id := strings.TrimSpace(ref.ID)
+			if cveIDPattern.MatchString(id) {
+				cveIDsMap[id] = true
+			}
 		}
 	}
 	cveIDs := []string{}


### PR DESCRIPTION
# What did you implement:
Change the format of the CVE-ID so that it will not be registered if it does not match the format of the CVE-ID(`^CVE-[0-9]{4}-[0-9]{4,}$`).

Fixes #229 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
The ones that disappear in diff are the ones that are not suitable for the format (e.g. "CVE-CVE-xxxx-xxxx", "CCVE-xxxx-xxxx", "xxxx-xxxx"), or because a space has been added, so that there are now two registered items. ( e.g. "CVE-xxxx-xxxx", "CVE-xxxx-xxxx ")
The reason for the addition in diff is that the CVE-IDs that used to only have the form of CVE-ID with spaces are now CVE-IDs with spaces removed. (master: "CVE-xxxx-xxxx " → PR: "CVE-xxxx-xxxx")

Translated with www.DeepL.com/Translator (free version)

```console
$ go-cve-dictionary.master fetch jvn --dbpath master.sqlite3
$ sqlite3 master.sqlite3
sqlite> .output master.txt
sqlite> SELECT DISTINCT cve_id FROM jvns;

$ go-cve-dictionary.pr fetch jvn --dbpath pr.sqlite3
sqlite> .output pr.txt
sqlite> SELECT DISTINCT cve_id FROM jvns;

$ diff master.txt pr.txt
1,3d0
< 2021-0404
< CCVE-2017-14051
< CCVE-2019-0776
20829c20826
< CVE-2009-0569 
---
> CVE-2009-0569
32489d32485
< CVE-2011-2685 
43247d43242
< CVE-2013-3579 
45251c45246
< CVE-2013-6030 
---
> CVE-2013-6030
52368d52362
< CVE-2014-7188z
62248d62241
< CVE-2015-9356 
70158d70150
< CVE-2016-7864 
73568c73560
< CVE-2017-10873 
---
> CVE-2017-10873
80158d80149
< CVE-2017-2223 
86544d86534
< CVE-2018-0625  
86592d86581
< CVE-2018-0672 
89145c89134
< CVE-2018-12147 
---
> CVE-2018-12147
92281d92269
< CVE-2018-16167 
100257d100244
< CVE-2018-8020 
121021c121008
< CVE-2020-14512 
---
> CVE-2020-14512
132341d132327
< CVE-20206-6781
135803d135788
< CVE-2021-28380　
137004,137005d136988
< CVE-CVE-2019-9812
< SEC Consult Vulnerability Lab Security Advisory < 20140521-0 >
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

