### PR TITLE
feat(db): add LastFetchedDate in fetchmeta

### DIFF
--- a/commands/fetchjvn.go
+++ b/commands/fetchjvn.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	db "github.com/vulsio/go-cve-dictionary/db"
@@ -28,30 +30,31 @@ func fetchJvn(_ *cobra.Command, args []string) (err error) {
 	driver, locked, err := db.NewDB(viper.GetString("dbtype"), viper.GetString("dbpath"), viper.GetBool("debug-sql"), db.Option{})
 	if err != nil {
 		if locked {
-			log.Errorf("Failed to initialize DB. Close DB connection before fetching. err: %s", err)
+			return xerrors.Errorf("Failed to initialize DB. Close DB connection before fetching. err: %w", err)
 		}
-		return err
+		return xerrors.Errorf("Failed to open DB. err: %w", err)
 	}
 
 	fetchMeta, err := driver.GetFetchMeta()
 	if err != nil {
-		log.Errorf("Failed to get FetchMeta from DB. err: %s", err)
-		return err
+		return xerrors.Errorf("Failed to get FetchMeta from DB. err: %w", err)
 	}
 	if fetchMeta.OutDated() {
-		log.Errorf("Failed to Insert CVEs into DB. SchemaVersion is old. SchemaVersion: %v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
-		return xerrors.New("Failed to Insert CVEs into DB. SchemaVersion is old")
+		return xerrors.Errorf("Failed to Insert CVEs into DB. err: SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
-
+	// If the fetch fails the first time (without SchemaVersion), the DB needs to be cleaned every time, so insert SchemaVersion.
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
-		log.Errorf("Failed to upsert FetchMeta to DB. err: %s", err)
-		return err
+		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
 
 	log.Infof("Inserting JVN into DB (%s).", driver.Name())
 	if err := driver.InsertJvn(args); err != nil {
-		log.Fatalf("Failed to insert. dbpath: %s, err: %s", viper.GetString("dbpath"), err)
-		return err
+		return xerrors.Errorf("Failed to insert. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
+	}
+
+	fetchMeta.LastFetchedDate = time.Now()
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
 
 	log.Infof("Finished fetching JVN.")

--- a/commands/fetchjvn.go
+++ b/commands/fetchjvn.go
@@ -52,7 +52,7 @@ func fetchJvn(_ *cobra.Command, args []string) (err error) {
 		return xerrors.Errorf("Failed to insert. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
 
-	fetchMeta.LastFetchedDate = time.Now()
+	fetchMeta.LastFetchedAt = time.Now()
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}

--- a/commands/fetchnvd.go
+++ b/commands/fetchnvd.go
@@ -55,7 +55,7 @@ func fetchNvd(_ *cobra.Command, args []string) (err error) {
 		return xerrors.Errorf("Failed to insert. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
 
-	fetchMeta.LastFetchedDate = time.Now()
+	fetchMeta.LastFetchedAt = time.Now()
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}

--- a/commands/fetchnvd.go
+++ b/commands/fetchnvd.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/vulsio/go-cve-dictionary/db"
@@ -31,30 +33,31 @@ func fetchNvd(_ *cobra.Command, args []string) (err error) {
 	driver, locked, err := db.NewDB(viper.GetString("dbtype"), viper.GetString("dbpath"), viper.GetBool("debug-sql"), db.Option{})
 	if err != nil {
 		if locked {
-			log.Errorf("Failed to initialize DB. Close DB connection before fetching. err: %s", err)
+			return xerrors.Errorf("Failed to initialize DB. Close DB connection before fetching. err: %w", err)
 		}
-		return err
+		return xerrors.Errorf("Failed to open DB. err: %w", err)
 	}
 
 	fetchMeta, err := driver.GetFetchMeta()
 	if err != nil {
-		log.Errorf("Failed to get FetchMeta from DB. err: %s", err)
-		return err
+		return xerrors.Errorf("Failed to get FetchMeta from DB. err: %w", err)
 	}
 	if fetchMeta.OutDated() {
-		log.Errorf("Failed to Insert CVEs into DB. SchemaVersion is old. SchemaVersion: %v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
-		return xerrors.New("Failed to Insert CVEs into DB. SchemaVersion is old")
+		return xerrors.Errorf("Failed to Insert CVEs into DB. err: SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
-
+	// If the fetch fails the first time (without SchemaVersion), the DB needs to be cleaned every time, so insert SchemaVersion.
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
-		log.Errorf("Failed to upsert FetchMeta to DB. err: %s", err)
-		return err
+		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
 
 	log.Infof("Inserting NVD into DB (%s).", driver.Name())
 	if err := driver.InsertNvd(args); err != nil {
-		log.Errorf("Failed to insert. dbpath: %s, err: %s", viper.GetString("dbpath"), err)
-		return err
+		return xerrors.Errorf("Failed to insert. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
+	}
+
+	fetchMeta.LastFetchedDate = time.Now()
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
 
 	log.Infof("Finished fetching NVD.")

--- a/commands/server.go
+++ b/commands/server.go
@@ -36,19 +36,17 @@ func executeServer(_ *cobra.Command, _ []string) (err error) {
 	driver, locked, err := db.NewDB(viper.GetString("dbtype"), viper.GetString("dbpath"), viper.GetBool("debug-sql"), db.Option{})
 	if err != nil {
 		if locked {
-			log.Errorf("Failed to initialize DB. Close DB connection before fetching. err: %s", err)
+			return xerrors.Errorf("Failed to initialize DB. Close DB connection before fetching. err: %w", err)
 		}
-		return err
+		return xerrors.Errorf("Failed to open DB. err: %w", err)
 	}
 
 	fetchMeta, err := driver.GetFetchMeta()
 	if err != nil {
-		log.Errorf("Failed to get FetchMeta from DB. err: %s", err)
-		return err
+		return xerrors.Errorf("Failed to get FetchMeta from DB. err: %w", err)
 	}
 	if fetchMeta.OutDated() {
-		log.Errorf("Failed to Insert CVEs into DB. SchemaVersion is old. SchemaVersion: %v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
-		return xerrors.New("Failed to Insert CVEs into DB. SchemaVersion is old")
+		return xerrors.Errorf("Failed to start server. err: SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
 
 	count := 0
@@ -77,8 +75,7 @@ func executeServer(_ *cobra.Command, _ []string) (err error) {
 
 	log.Infof("Starting HTTP Server...")
 	if err = server.Start(viper.GetBool("log-to-file"), viper.GetString("log-dir"), driver); err != nil {
-		log.Errorf("%s", err)
-		return err
+		return xerrors.Errorf("Failed to start server. err: %w", err)
 	}
 	return nil
 }

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -169,7 +169,7 @@ func (r *RDBDriver) GetFetchMeta() (fetchMeta *models.FetchMeta, err error) {
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, err
 		}
-		return &models.FetchMeta{GoCVEDictRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion}, nil
+		return &models.FetchMeta{GoCVEDictRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion, LastFetchedDate: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)}, nil
 	}
 
 	return fetchMeta, nil

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -169,7 +169,7 @@ func (r *RDBDriver) GetFetchMeta() (fetchMeta *models.FetchMeta, err error) {
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, err
 		}
-		return &models.FetchMeta{GoCVEDictRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion, LastFetchedDate: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)}, nil
+		return &models.FetchMeta{GoCVEDictRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion, LastFetchedAt: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)}, nil
 	}
 
 	return fetchMeta, nil

--- a/db/redis.go
+++ b/db/redis.go
@@ -34,20 +34,20 @@ import (
   └─────────────────────────────────────────┴──────────────────────┴───────────────────────────────────────────────────┘
 
 - Hash
-  ┌──────────────────┬─────────────────┬─────────────┬──────────────────────────────────────────────────┐
-  │     HASH         │      FIELD      │    VALUE    │             PURPOSE                              │
-  └──────────────────┴─────────────────┴─────────────┴──────────────────────────────────────────────────┘
-  ┌──────────────────┬─────────────────┬─────────────┬──────────────────────────────────────────────────┐
-  │ CVE#CVE#${CVEID} │ NVD/${JVNID}    │ ${CVEJSON}  │ Get CVEJSON by CVEID                             │
-  ├──────────────────┼─────────────────┼─────────────┼──────────────────────────────────────────────────┤
-  │ CVE#DEP          │ NVD/JVN         │    JSON     │ TO DELETE OUTDATED AND UNNEEDED FIELD AND MEMBER │
-  ├──────────────────┼─────────────────┼─────────────┼──────────────────────────────────────────────────┤
-  │ CVE#FETCHMETA    │ Revision        │ string      │ Get Go-Cve-Dictionary Binary Revision            │
-  ├──────────────────┼─────────────────┼─────────────┼──────────────────────────────────────────────────┤
-  │ CVE#FETCHMETA    │ SchemaVersion   │ uint        │ Get Go-Cve-Dictionary Schema Version             │
-  ├──────────────────┼─────────────────┼─────────────┼──────────────────────────────────────────────────┤
-  │ CVE#FETCHMETA    │ LastFetchedDate │ time.Time   │ Get Go-Cve-Dictionary Last Fetched Time          │
-  └──────────────────┴─────────────────┴─────────────┴──────────────────────────────────────────────────┘
+  ┌──────────────────┬───────────────┬─────────────┬──────────────────────────────────────────────────┐
+  │     HASH         │      FIELD    │    VALUE    │             PURPOSE                              │
+  └──────────────────┴───────────────┴─────────────┴──────────────────────────────────────────────────┘
+  ┌──────────────────┬───────────────┬─────────────┬──────────────────────────────────────────────────┐
+  │ CVE#CVE#${CVEID} │ NVD/${JVNID}  │ ${CVEJSON}  │ Get CVEJSON by CVEID                             │
+  ├──────────────────┼───────────────┼─────────────┼──────────────────────────────────────────────────┤
+  │ CVE#DEP          │ NVD/JVN       │    JSON     │ TO DELETE OUTDATED AND UNNEEDED FIELD AND MEMBER │
+  ├──────────────────┼───────────────┼─────────────┼──────────────────────────────────────────────────┤
+  │ CVE#FETCHMETA    │ Revision      │ string      │ Get Go-Cve-Dictionary Binary Revision            │
+  ├──────────────────┼───────────────┼─────────────┼──────────────────────────────────────────────────┤
+  │ CVE#FETCHMETA    │ SchemaVersion │ uint        │ Get Go-Cve-Dictionary Schema Version             │
+  ├──────────────────┼───────────────┼─────────────┼──────────────────────────────────────────────────┤
+  │ CVE#FETCHMETA    │ LastFetchedAt │ time.Time   │ Get Go-Cve-Dictionary Last Fetched Time          │
+  └──────────────────┴───────────────┴─────────────┴──────────────────────────────────────────────────┘
 
 **/
 
@@ -139,7 +139,7 @@ func (r *RedisDriver) GetFetchMeta() (*models.FetchMeta, error) {
 		return nil, xerrors.Errorf("Failed to Exists. err: %w", err)
 	}
 	if exists == 0 {
-		return &models.FetchMeta{GoCVEDictRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion, LastFetchedDate: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)}, nil
+		return &models.FetchMeta{GoCVEDictRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion, LastFetchedAt: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)}, nil
 	}
 
 	revision, err := r.conn.HGet(ctx, fetchMetaKey, "Revision").Result()
@@ -156,10 +156,10 @@ func (r *RedisDriver) GetFetchMeta() (*models.FetchMeta, error) {
 		return nil, xerrors.Errorf("Failed to ParseUint. err: %w", err)
 	}
 
-	datestr, err := r.conn.HGet(ctx, fetchMetaKey, "LastFetchedDate").Result()
+	datestr, err := r.conn.HGet(ctx, fetchMetaKey, "LastFetchedAt").Result()
 	if err != nil {
 		if !errors.Is(err, redis.Nil) {
-			return nil, xerrors.Errorf("Failed to HGet LastFetchedDate. err: %w", err)
+			return nil, xerrors.Errorf("Failed to HGet LastFetchedAt. err: %w", err)
 		}
 		datestr = time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
 	}
@@ -168,12 +168,12 @@ func (r *RedisDriver) GetFetchMeta() (*models.FetchMeta, error) {
 		return nil, xerrors.Errorf("Failed to Parse date. err: %w", err)
 	}
 
-	return &models.FetchMeta{GoCVEDictRevision: revision, SchemaVersion: uint(version), LastFetchedDate: date}, nil
+	return &models.FetchMeta{GoCVEDictRevision: revision, SchemaVersion: uint(version), LastFetchedAt: date}, nil
 }
 
 // UpsertFetchMeta upsert FetchMeta to Database
 func (r *RedisDriver) UpsertFetchMeta(fetchMeta *models.FetchMeta) error {
-	return r.conn.HSet(context.Background(), fetchMetaKey, map[string]interface{}{"Revision": config.Revision, "SchemaVersion": models.LatestSchemaVersion, "LastFetchedDate": fetchMeta.LastFetchedDate}).Err()
+	return r.conn.HSet(context.Background(), fetchMetaKey, map[string]interface{}{"Revision": config.Revision, "SchemaVersion": models.LatestSchemaVersion, "LastFetchedAt": fetchMeta.LastFetchedAt}).Err()
 }
 
 // Get Select Cve information from DB.

--- a/db/redis.go
+++ b/db/redis.go
@@ -34,18 +34,20 @@ import (
   └─────────────────────────────────────────┴──────────────────────┴───────────────────────────────────────────────────┘
 
 - Hash
-  ┌──────────────────┬───────────────┬─────────────┬──────────────────────────────────────────────────┐
-  │     HASH         │      FIELD    │    VALUE    │             PURPOSE                              │
-  └──────────────────┴───────────────┴─────────────┴──────────────────────────────────────────────────┘
-  ┌──────────────────┬───────────────┬─────────────┬──────────────────────────────────────────────────┐
-  │ CVE#CVE#${CVEID} │ NVD/${JVNID}  │ ${CVEJSON}  │ Get CVEJSON by CVEID                             │
-  ├──────────────────┼───────────────┼─────────────┼──────────────────────────────────────────────────┤
-  │ CVE#DEP          │ NVD/JVN       │    JSON     │ TO DELETE OUTDATED AND UNNEEDED FIELD AND MEMBER │
-  ├──────────────────┼───────────────┼─────────────┼──────────────────────────────────────────────────┤
-  │ CVE#FETCHMETA    │ Revision      │ string      │ Get Go-Cve-Dictionary Binary Revision            │
-  ├──────────────────┼───────────────┼─────────────┼──────────────────────────────────────────────────┤
-  │ CVE#FETCHMETA    │ SchemaVersion │ uint        │ Get Go-Cve-Dictionary Schema Version             │
-  └──────────────────┴───────────────┴─────────────┴──────────────────────────────────────────────────┘
+  ┌──────────────────┬─────────────────┬─────────────┬──────────────────────────────────────────────────┐
+  │     HASH         │      FIELD      │    VALUE    │             PURPOSE                              │
+  └──────────────────┴─────────────────┴─────────────┴──────────────────────────────────────────────────┘
+  ┌──────────────────┬─────────────────┬─────────────┬──────────────────────────────────────────────────┐
+  │ CVE#CVE#${CVEID} │ NVD/${JVNID}    │ ${CVEJSON}  │ Get CVEJSON by CVEID                             │
+  ├──────────────────┼─────────────────┼─────────────┼──────────────────────────────────────────────────┤
+  │ CVE#DEP          │ NVD/JVN         │    JSON     │ TO DELETE OUTDATED AND UNNEEDED FIELD AND MEMBER │
+  ├──────────────────┼─────────────────┼─────────────┼──────────────────────────────────────────────────┤
+  │ CVE#FETCHMETA    │ Revision        │ string      │ Get Go-Cve-Dictionary Binary Revision            │
+  ├──────────────────┼─────────────────┼─────────────┼──────────────────────────────────────────────────┤
+  │ CVE#FETCHMETA    │ SchemaVersion   │ uint        │ Get Go-Cve-Dictionary Schema Version             │
+  ├──────────────────┼─────────────────┼─────────────┼──────────────────────────────────────────────────┤
+  │ CVE#FETCHMETA    │ LastFetchedDate │ time.Time   │ Get Go-Cve-Dictionary Last Fetched Time          │
+  └──────────────────┴─────────────────┴─────────────┴──────────────────────────────────────────────────┘
 
 **/
 
@@ -137,7 +139,7 @@ func (r *RedisDriver) GetFetchMeta() (*models.FetchMeta, error) {
 		return nil, xerrors.Errorf("Failed to Exists. err: %w", err)
 	}
 	if exists == 0 {
-		return &models.FetchMeta{GoCVEDictRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion}, nil
+		return &models.FetchMeta{GoCVEDictRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion, LastFetchedDate: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)}, nil
 	}
 
 	revision, err := r.conn.HGet(ctx, fetchMetaKey, "Revision").Result()
@@ -154,12 +156,21 @@ func (r *RedisDriver) GetFetchMeta() (*models.FetchMeta, error) {
 		return nil, xerrors.Errorf("Failed to ParseUint. err: %w", err)
 	}
 
-	return &models.FetchMeta{GoCVEDictRevision: revision, SchemaVersion: uint(version)}, nil
+	datestr, err := r.conn.HGet(ctx, fetchMetaKey, "LastFetchedDate").Result()
+	if err != nil {
+		return nil, xerrors.Errorf("Failed to HGet LastFetchedDate. err: %w", err)
+	}
+	date, err := time.Parse(time.RFC3339, datestr)
+	if err != nil {
+		return nil, xerrors.Errorf("Failed to Parse date. err: %w", err)
+	}
+
+	return &models.FetchMeta{GoCVEDictRevision: revision, SchemaVersion: uint(version), LastFetchedDate: date}, nil
 }
 
 // UpsertFetchMeta upsert FetchMeta to Database
 func (r *RedisDriver) UpsertFetchMeta(fetchMeta *models.FetchMeta) error {
-	return r.conn.HSet(context.Background(), fetchMetaKey, map[string]interface{}{"Revision": fetchMeta.GoCVEDictRevision, "SchemaVersion": fetchMeta.SchemaVersion}).Err()
+	return r.conn.HSet(context.Background(), fetchMetaKey, map[string]interface{}{"Revision": config.Revision, "SchemaVersion": models.LatestSchemaVersion, "LastFetchedDate": fetchMeta.LastFetchedDate}).Err()
 }
 
 // Get Select Cve information from DB.

--- a/db/redis.go
+++ b/db/redis.go
@@ -158,7 +158,10 @@ func (r *RedisDriver) GetFetchMeta() (*models.FetchMeta, error) {
 
 	datestr, err := r.conn.HGet(ctx, fetchMetaKey, "LastFetchedDate").Result()
 	if err != nil {
-		return nil, xerrors.Errorf("Failed to HGet LastFetchedDate. err: %w", err)
+		if !errors.Is(err, redis.Nil) {
+			return nil, xerrors.Errorf("Failed to HGet LastFetchedDate. err: %w", err)
+		}
+		datestr = time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
 	}
 	date, err := time.Parse(time.RFC3339, datestr)
 	if err != nil {

--- a/models/models.go
+++ b/models/models.go
@@ -50,7 +50,7 @@ type FetchMeta struct {
 	gorm.Model        `json:"-"`
 	GoCVEDictRevision string
 	SchemaVersion     uint
-	LastFetchedDate   time.Time
+	LastFetchedAt     time.Time
 }
 
 // OutDated checks whether last fetched feed is out dated

--- a/models/models.go
+++ b/models/models.go
@@ -50,6 +50,7 @@ type FetchMeta struct {
 	gorm.Model        `json:"-"`
 	GoCVEDictRevision string
 	SchemaVersion     uint
+	LastFetchedDate   time.Time
 }
 
 // OutDated checks whether last fetched feed is out dated


### PR DESCRIPTION
# What did you implement:
Add the time when the fetch is completed to fetchmeta.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
## RDB
```console
$ go-cve-dictionary fetch nvd
$ sqlite3 cve.sqlite3  
sqlite> SELECT last_fetched_at FROM fetch_meta;
2021-12-26 08:45:48.769925148+09:00

$ go-cve-dictionary fetch nvd
$ sqlite3 cve.sqlite3  
sqlite> SELECT last_fetched_at FROM fetch_meta;
2021-12-26 08:50:40.68298214+09:00
```

## Redis
```console
$ redis-cli -p 6379
127.0.0.1:6379> HGET CVE#FETCHMETA LastFetchedAt
(nil)

$ go-cve-dictionary fetch nvd --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ redis-cli -p 6379
127.0.0.1:6379> HGET CVE#FETCHMETA LastFetchedAt
"2021-12-26T08:52:51.973265483+09:00"

$ go-cve-dictionary fetch nvd --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ redis-cli -p 6379
127.0.0.1:6379> HGET CVE#FETCHMETA LastFetchedAt
"2021-12-26T08:54:48.1066968+09:00"
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
