### PR TITLE
feat(fetch): fetch by year

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,13 +264,25 @@ Use "go-cve-dictionary fetch [command] --help" for more information about a comm
 ```
 
 #### Fetch NVD data
+- to fetch all years
 ```bash
 $ go-cve-dictionary fetch nvd
 ```
 
+- to fetch specific years
+```bash
+$ go-cve-dictionary fetch nvd 2021
+```
+
 #### Fetch JVN data
+- to fetch all years
 ```bash
 $ go-cve-dictionary fetch jvn
+```
+
+- to fetch specific years
+```bash
+$ go-cve-dictionary fetch jvn 2021
 ```
 ----
 

--- a/commands/fetchjvn.go
+++ b/commands/fetchjvn.go
@@ -20,7 +20,7 @@ func init() {
 	fetchCmd.AddCommand(fetchJvnCmd)
 }
 
-func fetchJvn(_ *cobra.Command, _ []string) (err error) {
+func fetchJvn(_ *cobra.Command, args []string) (err error) {
 	if err := log.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}
@@ -49,7 +49,7 @@ func fetchJvn(_ *cobra.Command, _ []string) (err error) {
 	}
 
 	log.Infof("Inserting JVN into DB (%s).", driver.Name())
-	if err := driver.InsertJvn(); err != nil {
+	if err := driver.InsertJvn(args); err != nil {
 		log.Fatalf("Failed to insert. dbpath: %s, err: %s", viper.GetString("dbpath"), err)
 		return err
 	}

--- a/commands/fetchnvd.go
+++ b/commands/fetchnvd.go
@@ -23,7 +23,7 @@ func init() {
 	_ = viper.BindPFlag("full", fetchNvdCmd.PersistentFlags().Lookup("full"))
 }
 
-func fetchNvd(_ *cobra.Command, _ []string) (err error) {
+func fetchNvd(_ *cobra.Command, args []string) (err error) {
 	if err := log.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}
@@ -52,7 +52,7 @@ func fetchNvd(_ *cobra.Command, _ []string) (err error) {
 	}
 
 	log.Infof("Inserting NVD into DB (%s).", driver.Name())
-	if err := driver.InsertNvd(); err != nil {
+	if err := driver.InsertNvd(args); err != nil {
 		log.Errorf("Failed to insert. dbpath: %s, err: %s", viper.GetString("dbpath"), err)
 		return err
 	}

--- a/db/db.go
+++ b/db/db.go
@@ -31,8 +31,8 @@ type DB interface {
 	GetMulti([]string) (map[string]models.CveDetail, error)
 	GetCveIDsByCpeURI(string) ([]string, []string, error)
 	GetByCpeURI(string) ([]models.CveDetail, error)
-	InsertJvn() error
-	InsertNvd() error
+	InsertJvn([]string) error
+	InsertNvd([]string) error
 	CountNvd() (int, error)
 	CountJvn() (int, error)
 }

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -352,7 +352,7 @@ func (r *RDBDriver) CountJvn() (int, error) {
 }
 
 // InsertJvn inserts Cve Information into DB
-func (r *RDBDriver) InsertJvn() error {
+func (r *RDBDriver) InsertJvn(years []string) error {
 	tx := r.conn.Begin()
 	defer func() {
 		if re := recover(); re != nil {
@@ -383,8 +383,12 @@ func (r *RDBDriver) InsertJvn() error {
 		return xerrors.Errorf("Failed to FetchConvert. err: %w", err)
 	}
 
-	for y := 1998; y <= time.Now().Year(); y++ {
-		year := fmt.Sprintf("%d", y)
+	if len(years) == 0 {
+		for y := 1998; y <= time.Now().Year(); y++ {
+			years = append(years, fmt.Sprintf("%d", y))
+		}
+	}
+	for _, year := range years {
 		logger.Infof("Fetching CVE information from JVN(%s).", year)
 		if err := jvn.FetchConvert(uniqCves, []string{year}); err != nil {
 			tx.Rollback()
@@ -463,7 +467,7 @@ func (r *RDBDriver) CountNvd() (int, error) {
 }
 
 // InsertNvd Cve information from DB.
-func (r *RDBDriver) InsertNvd() (err error) {
+func (r *RDBDriver) InsertNvd(years []string) (err error) {
 	tx := r.conn.Begin()
 	defer func() {
 		if re := recover(); re != nil {
@@ -494,8 +498,12 @@ func (r *RDBDriver) InsertNvd() (err error) {
 		return xerrors.Errorf("Failed to FetchConvert. err: %w", err)
 	}
 
-	for y := 2002; y <= time.Now().Year(); y++ {
-		year := fmt.Sprintf("%d", y)
+	if len(years) == 0 {
+		for y := 2002; y <= time.Now().Year(); y++ {
+			years = append(years, fmt.Sprintf("%d", y))
+		}
+	}
+	for _, year := range years {
 		logger.Infof("Fetching CVE information from NVD(%s).", year)
 		if err := nvd.FetchConvert(uniqCves, []string{year}); err != nil {
 			tx.Rollback()

--- a/db/redis.go
+++ b/db/redis.go
@@ -327,7 +327,7 @@ func (r *RedisDriver) CountJvn() (int, error) {
 }
 
 // InsertJvn insert items fetched from JVN.
-func (r *RedisDriver) InsertJvn() error {
+func (r *RedisDriver) InsertJvn(years []string) error {
 	ctx := context.Background()
 	batchSize := viper.GetInt("batch-size")
 	if batchSize < 1 {
@@ -357,8 +357,12 @@ func (r *RedisDriver) InsertJvn() error {
 		return xerrors.Errorf("Failed to unmarshal JSON. err: %w", err)
 	}
 
-	for y := 1998; y <= time.Now().Year(); y++ {
-		year := fmt.Sprintf("%d", y)
+	if len(years) == 0 {
+		for y := 1998; y <= time.Now().Year(); y++ {
+			years = append(years, fmt.Sprintf("%d", y))
+		}
+	}
+	for _, year := range years {
 		log.Infof("Fetching CVE information from JVN(%s).", year)
 		if err := jvn.FetchConvert(uniqCves, []string{year}); err != nil {
 			return xerrors.Errorf("Failed to FetchConvert. err: %w", err)
@@ -471,7 +475,7 @@ func (r *RedisDriver) CountNvd() (int, error) {
 }
 
 // InsertNvd Cve information from DB.
-func (r *RedisDriver) InsertNvd() error {
+func (r *RedisDriver) InsertNvd(years []string) error {
 	ctx := context.Background()
 	batchSize := viper.GetInt("batch-size")
 	if batchSize < 1 {
@@ -501,8 +505,12 @@ func (r *RedisDriver) InsertNvd() error {
 		return xerrors.Errorf("Failed to unmarshal JSON. err: %w", err)
 	}
 
-	for y := 2002; y <= time.Now().Year(); y++ {
-		year := fmt.Sprintf("%d", y)
+	if len(years) == 0 {
+		for y := 2002; y <= time.Now().Year(); y++ {
+			years = append(years, fmt.Sprintf("%d", y))
+		}
+	}
+	for _, year := range years {
 		log.Infof("Fetching CVE information from NVD(%s).", year)
 		if err := nvd.FetchConvert(uniqCves, []string{year}); err != nil {
 			return xerrors.Errorf("Failed to FetchConvert. err: %w", err)


### PR DESCRIPTION
# What did you implement:
Due to a change at https://github.com/vulsio/go-cve-dictionary/pull/214, go-cve-dictionary could no longer select a year to fetch.
However, if all the years were to be fetched, the DB size would become too large, and there would be a demand for only certain years, etc., so I added the ability to select and fetch years.

Fixes #231 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
## Difference in fetch behavior
If you selected years in the previous fetch command, they were added to the DB, but the current fetch command will recreate a new DB with only the selected years. 
### v0.7.1 and earlier
```console
$ go-cve-dictionary fetch nvd --years 2020
$ sqlite3 cve.sqlite3
sqlite> SELECT * FROM nvds LIMIT 3;
id|feed_meta_id|cve_id|published_date|last_modified_date
1|1|CVE-2020-0003|2020-01-08 19:15:00+00:00|2020-01-29 21:15:00+00:00
2|1|CVE-2020-0002|2020-01-08 19:15:00+00:00|2021-07-21 11:39:00+00:00
3|1|CVE-2020-0001|2020-01-08 19:15:00+00:00|2021-07-21 11:39:00+00:00

$ go-cve-dictionary fetch nvd --years 2021
$ sqlite3 cve.sqlite3
sqlite> SELECT * FROM nvds WHERE cve_id LIKE "CVE-2020-%" LIMIT 3;
id|feed_meta_id|cve_id|published_date|last_modified_date
1|1|CVE-2020-0003|2020-01-08 19:15:00+00:00|2020-01-29 21:15:00+00:00
2|1|CVE-2020-0002|2020-01-08 19:15:00+00:00|2021-07-21 11:39:00+00:00
3|1|CVE-2020-0001|2020-01-08 19:15:00+00:00|2021-07-21 11:39:00+00:00
sqlite> SELECT * FROM nvds WHERE cve_id LIKE "CVE-2021-%" LIMIT 3;
id|feed_meta_id|cve_id|published_date|last_modified_date
17855|2|CVE-2021-45470|2021-12-23 21:15:00+00:00|2021-12-23 21:15:00+00:00
17856|2|CVE-2021-3622|2021-12-23 21:15:00+00:00|2021-12-23 21:15:00+00:00
17857|2|CVE-2021-3621|2021-12-23 21:15:00+00:00|2021-12-23 21:15:00+00:00
```

### MaineK00n/fetch-by-year
```console
$ go-cve-dictionary fetch nvd 2020
$ sqlite3 cve.sqlite3
sqlite> SELECT * FROM nvds LIMIT 3;
id|cve_id|published_date|last_modified_date
1|CVE-2020-17473|2020-08-14 20:15:00+00:00|2020-08-21 15:00:00+00:00
2|CVE-2020-25990|2020-10-01 14:15:00+00:00|2020-10-05 15:58:00+00:00
3|CVE-2020-35592|2021-02-18 20:15:00+00:00|2021-02-24 15:42:00+00:00

$ go-cve-dictionary fetch nvd 2021
$ sqlite3 cve.sqlite3
sqlite> SELECT * FROM nvds LIMIT 3;
id|cve_id|published_date|last_modified_date
1|CVE-2021-38947|2021-12-13 18:15:00+00:00|2021-12-15 16:56:00+00:00
2|CVE-2021-34612|2021-07-08 20:15:00+00:00|2021-07-12 17:42:00+00:00
3|CVE-2021-23840|2021-02-16 17:15:00+00:00|2021-12-10 18:12:00+00:00
sqlite> SELECT * FROM nvds WHERE cve_id LIKE "CVE-2020-%";

$ go-cve-dictionary fetch nvd 2020 2021 // If you want to fetch both 2020 and 2021
$ sqlite3 cve.sqlite3
sqlite> SELECT * FROM nvds WHERE cve_id LIKE "CVE-2020-%" LIMIT 3;
id|cve_id|published_date|last_modified_date
1|CVE-2020-0046|2020-03-10 21:15:00+00:00|2020-03-11 18:13:00+00:00
2|CVE-2020-4375|2020-07-28 12:15:00+00:00|2021-07-21 11:39:00+00:00
3|CVE-2020-5509|2020-01-14 19:15:00+00:00|2020-01-21 19:14:00+00:00
sqlite> SELECT * FROM nvds WHERE cve_id LIKE "CVE-2021-%" LIMIT 3;
id|cve_id|published_date|last_modified_date
17857|CVE-2021-38006|2021-12-23 01:15:00+00:00|2021-12-23 15:25:00+00:00
17858|CVE-2021-39931|2021-12-13 16:15:00+00:00|2021-12-16 03:09:00+00:00
17859|CVE-2021-39863|2021-09-29 16:15:00+00:00|2021-10-06 16:45:00+00:00
```

## Behavior of the fetch command when no year is entered
Fetch all the years as before.
```console
$ go-cve-dictionary fetch nvd
INFO[12-24|08:21:40] Inserting NVD into DB (sqlite3). 
INFO[12-24|08:21:40] Deleting NVD tables... 
INFO[12-24|08:21:40] Fetching CVE information from NVD(recent, modified). 
INFO[12-24|08:21:40] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-recent.json.gz 
INFO[12-24|08:21:41] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-modified.json.gz 
INFO[12-24|08:21:42] Fetching CVE information from NVD(2002). 
INFO[12-24|08:21:42] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2002.json.gz 
INFO[12-24|08:21:45] Inserting fetched CVEs(2002)... 
2356 / 2356 [---------------------------------------------------------------------------------------------------------] 100.00% 4018 p/s
INFO[12-24|08:21:46] Refreshed 2356 CVEs. 
INFO[12-24|08:21:46] Fetching CVE information from NVD(2003). 
INFO[12-24|08:21:46] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2003.json.gz 
INFO[12-24|08:21:47] Inserting fetched CVEs(2003)... 
1500 / 1500 [---------------------------------------------------------------------------------------------------------] 100.00% 3843 p/s
INFO[12-24|08:21:48] Refreshed 1500 CVEs. 
INFO[12-24|08:21:48] Fetching CVE information from NVD(2004). 
INFO[12-24|08:21:48] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2004.json.gz 
INFO[12-24|08:21:50] Inserting fetched CVEs(2004)... 
2644 / 2644 [---------------------------------------------------------------------------------------------------------] 100.00% 2227 p/s
INFO[12-24|08:21:51] Refreshed 2644 CVEs. 
INFO[12-24|08:21:51] Fetching CVE information from NVD(2005). 
INFO[12-24|08:21:51] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2005.json.gz 
INFO[12-24|08:21:53] Inserting fetched CVEs(2005)... 
4623 / 4623 [---------------------------------------------------------------------------------------------------------] 100.00% 2488 p/s
INFO[12-24|08:21:56] Refreshed 4623 CVEs. 
INFO[12-24|08:21:56] Fetching CVE information from NVD(2006). 
INFO[12-24|08:21:56] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2006.json.gz 
INFO[12-24|08:21:58] Inserting fetched CVEs(2006)... 
6991 / 6991 [---------------------------------------------------------------------------------------------------------] 100.00% 2566 p/s
INFO[12-24|08:22:01] Refreshed 6991 CVEs. 
INFO[12-24|08:22:01] Fetching CVE information from NVD(2007). 
INFO[12-24|08:22:01] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2007.json.gz 
INFO[12-24|08:22:05] Inserting fetched CVEs(2007)... 
6454 / 6454 [---------------------------------------------------------------------------------------------------------] 100.00% 2563 p/s
INFO[12-24|08:22:07] Refreshed 6454 CVEs. 
INFO[12-24|08:22:07] Fetching CVE information from NVD(2008). 
INFO[12-24|08:22:07] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2008.json.gz 
INFO[12-24|08:22:10] Inserting fetched CVEs(2008)... 
7000 / 7000 [---------------------------------------------------------------------------------------------------------] 100.00% 2039 p/s
INFO[12-24|08:22:14] Refreshed 7000 CVEs. 
INFO[12-24|08:22:14] Fetching CVE information from NVD(2009). 
INFO[12-24|08:22:14] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2009.json.gz 
INFO[12-24|08:22:17] Inserting fetched CVEs(2009)... 
4902 / 4902 [---------------------------------------------------------------------------------------------------------] 100.00% 1181 p/s
INFO[12-24|08:22:22] Refreshed 4902 CVEs. 
INFO[12-24|08:22:22] Fetching CVE information from NVD(2010). 
INFO[12-24|08:22:22] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2010.json.gz 
INFO[12-24|08:22:25] Inserting fetched CVEs(2010)... 
5037 / 5037 [---------------------------------------------------------------------------------------------------------] 100.00% 1143 p/s
INFO[12-24|08:22:30] Refreshed 5037 CVEs. 
INFO[12-24|08:22:30] Fetching CVE information from NVD(2011). 
INFO[12-24|08:22:30] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2011.json.gz 
INFO[12-24|08:22:33] Inserting fetched CVEs(2011)... 
4599 / 4599 [----------------------------------------------------------------------------------------------------------] 100.00% 705 p/s
INFO[12-24|08:22:40] Refreshed 4599 CVEs. 
INFO[12-24|08:22:40] Fetching CVE information from NVD(2012). 
INFO[12-24|08:22:40] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2012.json.gz 
INFO[12-24|08:22:44] Inserting fetched CVEs(2012)... 
5419 / 5419 [----------------------------------------------------------------------------------------------------------] 100.00% 877 p/s
INFO[12-24|08:22:50] Refreshed 5419 CVEs. 
INFO[12-24|08:22:50] Fetching CVE information from NVD(2013). 
INFO[12-24|08:22:50] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2013.json.gz 
INFO[12-24|08:22:55] Inserting fetched CVEs(2013)... 
6135 / 6135 [----------------------------------------------------------------------------------------------------------] 100.00% 900 p/s
INFO[12-24|08:23:02] Refreshed 6135 CVEs. 
INFO[12-24|08:23:02] Fetching CVE information from NVD(2014). 
INFO[12-24|08:23:02] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2014.json.gz 
INFO[12-24|08:23:05] Inserting fetched CVEs(2014)... 
8289 / 8289 [---------------------------------------------------------------------------------------------------------] 100.00% 1857 p/s
INFO[12-24|08:23:10] Refreshed 8289 CVEs. 
INFO[12-24|08:23:10] Fetching CVE information from NVD(2015). 
INFO[12-24|08:23:10] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2015.json.gz 
INFO[12-24|08:23:13] Inserting fetched CVEs(2015)... 
7923 / 7923 [---------------------------------------------------------------------------------------------------------] 100.00% 1760 p/s
INFO[12-24|08:23:18] Refreshed 7923 CVEs. 
INFO[12-24|08:23:18] Fetching CVE information from NVD(2016). 
INFO[12-24|08:23:18] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2016.json.gz 
INFO[12-24|08:23:21] Inserting fetched CVEs(2016)... 
9213 / 9213 [---------------------------------------------------------------------------------------------------------] 100.00% 1782 p/s
INFO[12-24|08:23:27] Refreshed 9213 CVEs. 
INFO[12-24|08:23:27] Fetching CVE information from NVD(2017). 
INFO[12-24|08:23:27] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2017.json.gz 
INFO[12-24|08:23:31] Inserting fetched CVEs(2017)... 
14383 / 14383 [-------------------------------------------------------------------------------------------------------] 100.00% 1935 p/s
INFO[12-24|08:23:39] Refreshed 14383 CVEs. 
INFO[12-24|08:23:39] Fetching CVE information from NVD(2018). 
INFO[12-24|08:23:39] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2018.json.gz 
INFO[12-24|08:23:43] Inserting fetched CVEs(2018)... 
15629 / 15629 [-------------------------------------------------------------------------------------------------------] 100.00% 2221 p/s
INFO[12-24|08:23:50] Refreshed 15629 CVEs. 
INFO[12-24|08:23:50] Fetching CVE information from NVD(2019). 
INFO[12-24|08:23:50] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2019.json.gz 
INFO[12-24|08:23:55] Inserting fetched CVEs(2019)... 
15385 / 15385 [-------------------------------------------------------------------------------------------------------] 100.00% 2074 p/s
INFO[12-24|08:24:02] Refreshed 15385 CVEs. 
INFO[12-24|08:24:02] Fetching CVE information from NVD(2020). 
INFO[12-24|08:24:02] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2020.json.gz 
INFO[12-24|08:24:09] Inserting fetched CVEs(2020)... 
17856 / 17856 [-------------------------------------------------------------------------------------------------------] 100.00% 1784 p/s
INFO[12-24|08:24:19] Refreshed 17856 CVEs. 
INFO[12-24|08:24:19] Fetching CVE information from NVD(2021). 
INFO[12-24|08:24:19] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2021.json.gz 
INFO[12-24|08:24:24] Inserting fetched CVEs(2021)... 
15775 / 15775 [-------------------------------------------------------------------------------------------------------] 100.00% 1955 p/s
INFO[12-24|08:24:32] Refreshed 15775 CVEs. 
INFO[12-24|08:24:32] Finished fetching NVD.
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES 

# Reference
