### PR TITLE
chore(fetch/jvn): logging when invalid CVE-ID is found

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -37,6 +37,7 @@ type DB interface {
 	CountJvn() (int, error)
 }
 
+// Option :
 type Option struct {
 	RedisTimeout time.Duration
 }

--- a/fetcher/jvn/jvn.go
+++ b/fetcher/jvn/jvn.go
@@ -414,11 +414,16 @@ func getCveIDs(item Item) []string {
 	for _, ref := range item.References {
 		switch ref.Source {
 		case "NVD", "CVE":
-			id := strings.TrimSpace(ref.ID)
-			if cveIDPattern.MatchString(id) {
-				cveIDsMap[id] = true
+			if cveIDPattern.MatchString(ref.ID) {
+				cveIDsMap[ref.ID] = true
 			} else {
-				log.Warnf("Failed to get CVE-ID. Invalid CVE-ID: %s", ref.ID)
+				id := strings.TrimSpace(ref.ID)
+				if cveIDPattern.MatchString(id) {
+					log.Warnf("CVE-ID with extra space. Please email JVNDB (isec-jvndb@ipa.go.jp) to fix the rdf file with the following information. RDF data(Identifier: %s, Reference Source: %s, ID: %s)", item.Identifier, ref.Source, ref.ID)
+					cveIDsMap[id] = true
+				} else {
+					log.Warnf("Failed to get CVE-ID. Invalid CVE-ID. Please email JVNDB (isec-jvndb@ipa.go.jp) to fix the rdf file with the following information. RDF data(Identifier: %s, Reference Source: %s, ID: %s)", item.Identifier, ref.Source, ref.ID)
+				}
 			}
 		}
 	}

--- a/fetcher/jvn/jvn.go
+++ b/fetcher/jvn/jvn.go
@@ -417,6 +417,8 @@ func getCveIDs(item Item) []string {
 			id := strings.TrimSpace(ref.ID)
 			if cveIDPattern.MatchString(id) {
 				cveIDsMap[id] = true
+			} else {
+				log.Warnf("Failed to get CVE-ID. Invalid CVE-ID: %s", ref.ID)
 			}
 		}
 	}

--- a/fetcher/jvn/jvn_test.go
+++ b/fetcher/jvn/jvn_test.go
@@ -62,3 +62,47 @@ func TestDistributeCvesByYear(t *testing.T) {
 		}
 	}
 }
+
+func TestGetCveIDs(t *testing.T) {
+	var tests = []struct {
+		in       Item
+		expected []string
+	}{
+		{
+			in: Item{
+				Identifier: "success",
+				References: []references{{
+					Source: "NVD",
+					ID:     "CVE-0000-0001",
+				}},
+			},
+			expected: []string{"CVE-0000-0001"},
+		},
+		{
+			in: Item{
+				Identifier: "extra space",
+				References: []references{{
+					Source: "NVD",
+					ID:     "CVE-0000-0002 ",
+				}},
+			},
+			expected: []string{"CVE-0000-0002"},
+		},
+		{
+			in: Item{
+				Identifier: "invalid CVE-ID",
+				References: []references{{
+					Source: "NVD",
+					ID:     "CCVE-0000-0003",
+				}},
+			},
+			expected: []string{},
+		},
+	}
+
+	for i, tt := range tests {
+		if got := getCveIDs(tt.in); !reflect.DeepEqual(got, tt.expected) {
+			t.Errorf("[%d] expected: %v\n  actual: %v\n", i, tt.expected, got)
+		}
+	}
+}


### PR DESCRIPTION
# What did you implement:
Logging when a invalid CVEID is found.

refs. https://github.com/vulsio/go-cve-dictionary/pull/233

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
```console
$ go-cve-dictionary fetch jvn
...
WARN[12-28|12:04:14] Failed to get CVE-ID. Invalid CVE-ID: CCVE-2021-20208 
INFO[12-28|12:04:14] Inserting fetched CVEs(2021)... 
5544 / 5544 [-------------------------------------------------] 100.00% 2876 p/s
INFO[12-28|12:04:17] Refreshed 5544 CVEs. 
INFO[12-28|12:04:17] Finished fetching JVN.
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

