### PR TITLE
fix(cpescan): match if affected version is NA

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -118,17 +118,17 @@ func parseCpeURI(cpe22uri string) (*models.CpeBase, error) {
 		FormattedString: naming.BindToFS(wfn),
 		WellFormedName:  wfn.String(),
 		CpeWFN: models.CpeWFN{
-			Part:            fmt.Sprintf("%s", wfn.Get(common.AttributePart)),
-			Vendor:          fmt.Sprintf("%s", wfn.Get(common.AttributeVendor)),
-			Product:         fmt.Sprintf("%s", wfn.Get(common.AttributeProduct)),
-			Version:         fmt.Sprintf("%s", wfn.Get(common.AttributeVersion)),
-			Update:          fmt.Sprintf("%s", wfn.Get(common.AttributeUpdate)),
-			Edition:         fmt.Sprintf("%s", wfn.Get(common.AttributeEdition)),
-			Language:        fmt.Sprintf("%s", wfn.Get(common.AttributeLanguage)),
-			SoftwareEdition: fmt.Sprintf("%s", wfn.Get(common.AttributeSwEdition)),
-			TargetSW:        fmt.Sprintf("%s", wfn.Get(common.AttributeTargetSw)),
-			TargetHW:        fmt.Sprintf("%s", wfn.Get(common.AttributeTargetHw)),
-			Other:           fmt.Sprintf("%s", wfn.Get(common.AttributeOther)),
+			Part:            wfn.GetString(common.AttributePart),
+			Vendor:          wfn.GetString(common.AttributeVendor),
+			Product:         wfn.GetString(common.AttributeProduct),
+			Version:         wfn.GetString(common.AttributeVersion),
+			Update:          wfn.GetString(common.AttributeUpdate),
+			Edition:         wfn.GetString(common.AttributeEdition),
+			Language:        wfn.GetString(common.AttributeLanguage),
+			SoftwareEdition: wfn.GetString(common.AttributeSwEdition),
+			TargetSW:        wfn.GetString(common.AttributeTargetSw),
+			TargetHW:        wfn.GetString(common.AttributeTargetHw),
+			Other:           wfn.GetString(common.AttributeOther),
 		},
 	}, nil
 }
@@ -206,7 +206,7 @@ func match(specifiedURI string, cpeInNvd models.CpeBase) (isExactVerMatch, isRou
 		return false, false, false, nil
 	}
 
-	specifiedVer := fmt.Sprintf("%s", specified.Get(common.AttributeVersion))
+	specifiedVer := specified.GetString(common.AttributeVersion)
 	switch specifiedVer {
 	case "NA", "ANY":
 		if err := cpeInNvdWfn.Set(common.AttributeVersion, nil); err != nil {
@@ -220,7 +220,7 @@ func match(specifiedURI string, cpeInNvd models.CpeBase) (isExactVerMatch, isRou
 		return true, false, false, nil
 	}
 
-	if fmt.Sprintf("%s", cpeInNvdWfn.Get(common.AttributeVersion)) == "NA" {
+	if cpeInNvdWfn.GetString(common.AttributeVersion) == "NA" {
 		log.Debugf("%s matches %s", specified.String(), cpeInNvd.URI)
 		return true, false, false, nil
 	}
@@ -247,8 +247,7 @@ func match(specifiedURI string, cpeInNvd models.CpeBase) (isExactVerMatch, isRou
 	// In this case, target_sw does not match and returns false
 	// - config.toml:  	"cpe:/a:apache:cordova:5.1.1::~~~iphone_os~~",
 	// - AffectedCPEInNVD:    "cpe:/a:apache:cordova:5.1.1::~~~android~~",
-	if fmt.Sprintf("%s", specified.Get(common.AttributeVersion)) !=
-		fmt.Sprintf("%s", cpeInNvdWfn.Get(common.AttributeVersion)) {
+	if specified.GetString(common.AttributeVersion) != cpeInNvdWfn.GetString(common.AttributeVersion) {
 		return false, false, false, nil
 	}
 	return isSuperORSubset(cpeInNvdWfn, specified), false, false, nil

--- a/db/db.go
+++ b/db/db.go
@@ -220,6 +220,11 @@ func match(specifiedURI string, cpeInNvd models.CpeBase) (isExactVerMatch, isRou
 		return true, false, false, nil
 	}
 
+	if fmt.Sprintf("%s", cpeInNvdWfn.Get(common.AttributeVersion)) == "NA" {
+		log.Debugf("%s matches %s", specified.String(), cpeInNvd.URI)
+		return true, false, false, nil
+	}
+
 	ok, err := matchSemver(specifiedVer, cpeInNvd)
 	if err != nil {
 		// version range specified in cpeInNvd are not defined as semver style

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -297,6 +297,16 @@ func TestMatch(t *testing.T) {
 			wantIsRoughVerMatch:      false,
 			wantIsVendorProductMatch: false,
 		},
+		{
+			name: "true: NA should match all version",
+			uri:  "cpe:/h:fortinet:fortigate-100d:v6.2.9",
+			cpe: models.CpeBase{
+				URI: "cpe:/h:fortinet:fortigate-100d:v6.2.9:-",
+			},
+			wantIsExactVerMatch:      true,
+			wantIsRoughVerMatch:      false,
+			wantIsVendorProductMatch: false,
+		},
 	}
 
 	for _, tt := range testdata {

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -287,6 +287,16 @@ func TestMatch(t *testing.T) {
 			wantIsRoughVerMatch:      false,
 			wantIsVendorProductMatch: false,
 		},
+		{
+			name: "true: NA should match all version",
+			uri:  "cpe:/h:fortinet:fortigate-100d:v6.2.9",
+			cpe: models.CpeBase{
+				URI: "cpe:/h:fortinet:fortigate-100d:-",
+			},
+			wantIsExactVerMatch:      true,
+			wantIsRoughVerMatch:      false,
+			wantIsVendorProductMatch: false,
+		},
 	}
 
 	for _, tt := range testdata {


### PR DESCRIPTION
# What did you implement:

```
		{
			name: "true: NA should match all version",
			uri:  "cpe:/h:fortinet:fortigate-100d:v6.2.9",
			cpe: models.CpeBase{
				URI: "cpe:/h:fortinet:fortigate-100d:-",
			},
			wantIsExactVerMatch:      true,
			wantIsRoughVerMatch:      false,
			wantIsVendorProductMatch: false,
		},
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?


# Checklist:

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES