### PR TITLE
feat(fetch-jvn): add without-jvncert option

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,12 +246,13 @@ Available Commands:
   nvd         Fetch Vulnerability dictionary from NVD
 
 Flags:
-      --batch-size int   The number of batch size to insert. NOTE: This Option does not work for dbtype: redis. (default 5)
-  -h, --help             help for fetch
+      --batch-size int    The number of batch size to insert. (default 5)
+  -h, --help              help for fetch
+      --without-jvncert   not request to jvn cert (only jvn).
 
 Global Flags:
       --config string       config file (default is $HOME/.go-cve-dictionary.yaml)
-      --dbpath string       /path/to/sqlite3 or SQL connection string (default "$PWD/cve.sqlite3")
+      --dbpath string       /path/to/sqlite3 or SQL connection string (default "/go-cve-dictionary/cve.sqlite3")
       --dbtype string       Database type to store data in (sqlite3, mysql, postgres or redis supported) (default "sqlite3")
       --debug               debug mode (default: false)
       --debug-sql           SQL debug mode

--- a/commands/fetch.go
+++ b/commands/fetch.go
@@ -16,4 +16,7 @@ func init() {
 
 	fetchCmd.PersistentFlags().Int("batch-size", 5, "The number of batch size to insert.")
 	_ = viper.BindPFlag("batch-size", fetchCmd.PersistentFlags().Lookup("batch-size"))
+
+	fetchCmd.PersistentFlags().Bool("without-jvncert", false, "not request to jvn cert (only jvn).")
+	_ = viper.BindPFlag("without-jvncert", fetchCmd.PersistentFlags().Lookup("without-jvncert"))
 }

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -15,7 +15,7 @@ import (
 	"golang.org/x/xerrors"
 )
 
-//FetchFeedFile fetches vulnerability feed file concurrently
+// FetchFeedFile fetches vulnerability feed file concurrently
 func FetchFeedFile(urlstr string, gzip bool) (body []byte, err error) {
 	log.Infof("Fetching... %s", urlstr)
 

--- a/fetcher/jvn/jvn.go
+++ b/fetcher/jvn/jvn.go
@@ -292,7 +292,7 @@ func collectCertLinks(links []string) (certs []models.JvnCert, err error) {
 	certs = []models.JvnCert{}
 	for _, link := range links {
 		title := ""
-		if ! viper.GetBool("without-jvncert") {
+		if !viper.GetBool("without-jvncert") {
 			if strings.HasSuffix(link, ".html") {
 				res, err := httpClient.Get(link)
 				if err != nil {

--- a/fetcher/jvn/jvn.go
+++ b/fetcher/jvn/jvn.go
@@ -292,18 +292,20 @@ func collectCertLinks(links []string) (certs []models.JvnCert, err error) {
 	certs = []models.JvnCert{}
 	for _, link := range links {
 		title := ""
-		if strings.HasSuffix(link, ".html") {
-			res, err := httpClient.Get(link)
-			if err != nil {
-				return nil, xerrors.Errorf("Failed to get %s: err: %w", link, err)
-			}
-			defer res.Body.Close()
+		if ! viper.GetBool("without-jvncert") {
+			if strings.HasSuffix(link, ".html") {
+				res, err := httpClient.Get(link)
+				if err != nil {
+					return nil, xerrors.Errorf("Failed to get %s: err: %w", link, err)
+				}
+				defer res.Body.Close()
 
-			doc, err := goquery.NewDocumentFromReader(res.Body)
-			if err != nil {
-				return nil, xerrors.Errorf("Failed to NewDocumentFromReader. err: %w", err)
+				doc, err := goquery.NewDocumentFromReader(res.Body)
+				if err != nil {
+					return nil, xerrors.Errorf("Failed to NewDocumentFromReader. err: %w", err)
+				}
+				title = doc.Find("title").Text()
 			}
-			title = doc.Find("title").Text()
 		}
 		certs = append(certs, models.JvnCert{
 			Cert: models.Cert{


### PR DESCRIPTION
# What did you implement:

Fixes #334

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I execute that in docker.

```bash
$ docker build . -t temp
$ docker run --rm -it     -v $PWD:/go-cve-dictionary     temp fetch jvn --without-jvncert
INFO[09-08|23:40:35] Inserting JVN into DB (sqlite3). 
...
INFO[09-08|23:42:21] Finished fetching JVN. 
```

# Checklist:

- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
