### PR TITLE
feat(fortinet): new support for fortinet data feed

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -125,3 +125,63 @@ jobs:
       - name: fetch redis
         if: ${{ steps.build.conclusion == 'success' && ( success() || failure() )}}
         run: ./go-cve-dictionary fetch --dbtype redis --dbpath "redis://127.0.0.1:6379/0" jvn
+
+  fetch-fortinet:
+    name: fetch-fortinet
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_ROOT_PASSWORD: password
+          MYSQL_DATABASE: test
+        options: >-
+          --health-cmd "mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      postgres:
+        image: postgres
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+      - name: build
+        id: build
+        run: make build
+      - name: fetch sqlite3
+        if: ${{ steps.build.conclusion == 'success' && ( success() || failure() )}}
+        run: ./go-cve-dictionary fetch --dbtype sqlite3 fortinet
+      - name: fetch mysql
+        if: ${{ steps.build.conclusion == 'success' && ( success() || failure() )}}
+        run: ./go-cve-dictionary fetch --dbtype mysql --dbpath "root:password@tcp(127.0.0.1:3306)/test?parseTime=true" fortinet
+      - name: fetch postgres
+        if: ${{ steps.build.conclusion == 'success' && ( success() || failure() )}}
+        run: ./go-cve-dictionary fetch --dbtype postgres --dbpath "host=127.0.0.1 user=postgres dbname=test sslmode=disable password=password" fortinet
+      - name: fetch redis
+        if: ${{ steps.build.conclusion == 'success' && ( success() || failure() )}}
+        run: ./go-cve-dictionary fetch --dbtype redis --dbpath "redis://127.0.0.1:6379/0" fortinet

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Usage:
   go-cve-dictionary fetch [command]
 
 Available Commands:
+  fortinet    Fetch Vulnerability dictionary from Fortinet Advisories
   jvn         Fetch Vulnerability dictionary from JVN
   nvd         Fetch Vulnerability dictionary from NVD
 
@@ -284,6 +285,12 @@ $ go-cve-dictionary fetch jvn
 ```bash
 $ go-cve-dictionary fetch jvn 2021
 ```
+
+#### Fetch Fortinet data
+```bash
+$ go-cve-dictionary fetch fortinet
+```
+
 ----
 
 ### Usage: Run HTTP Server
@@ -332,6 +339,14 @@ Global Flags:
           --dbpath "user:pass@tcp(localhost:3306)/dbname?parseTime=true"
     ```
 
+- fetch fortinet
+
+    ```bash
+    $ go-cve-dictionary fetch fortinet \
+          --dbtype mysql \
+          --dbpath "user:pass@tcp(localhost:3306)/dbname?parseTime=true"
+    ```
+
 - server
 
     ```bash
@@ -358,6 +373,14 @@ Global Flags:
           --dbpath "host=myhost user=user dbname=dbname sslmode=disable password=password"
     ```
 
+- fetch fortinet
+
+    ```bash
+    $ go-cve-dictionary fetch fortinet \
+          --dbtype postgres \
+          --dbpath "host=myhost user=user dbname=dbname sslmode=disable password=password"
+    ```
+
 - server
 
     ```bash
@@ -380,6 +403,14 @@ Global Flags:
 
     ```bash
     $ go-cve-dictionary fetch jvn \
+          --dbtype redis \
+          --dbpath "redis://localhost/0"
+    ```
+
+- fetch fortinet
+
+    ```bash
+    $ go-cve-dictionary fetch fortinet \
           --dbtype redis \
           --dbpath "redis://localhost/0"
     ```
@@ -434,6 +465,7 @@ Run with --debug, --debug-sql option.
 
 - [NVD](https://nvd.nist.gov/)
 - [JVN(Japanese)](http://jvndb.jvn.jp/apis/myjvn/)
+- [Fortinet(https://www.fortiguard.com/psirt)](https://github.com/vulsio/vuls-data-raw-fortinet)
 
 ----
 

--- a/commands/fetchfortinet.go
+++ b/commands/fetchfortinet.go
@@ -1,0 +1,69 @@
+package commands
+
+import (
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"golang.org/x/xerrors"
+
+	db "github.com/vulsio/go-cve-dictionary/db"
+	"github.com/vulsio/go-cve-dictionary/fetcher/fortinet"
+	log "github.com/vulsio/go-cve-dictionary/log"
+	"github.com/vulsio/go-cve-dictionary/models"
+)
+
+var fetchFortinetCmd = &cobra.Command{
+	Use:   "fortinet",
+	Short: "Fetch Vulnerability dictionary from Fortinet Advisories",
+	Long:  "Fetch Vulnerability dictionary from Fortinet Advisories",
+	RunE:  fetchFortinet,
+}
+
+func init() {
+	fetchCmd.AddCommand(fetchFortinetCmd)
+}
+
+func fetchFortinet(_ *cobra.Command, _ []string) (err error) {
+	if err := log.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
+		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
+	}
+
+	driver, err := db.NewDB(viper.GetString("dbtype"), viper.GetString("dbpath"), viper.GetBool("debug-sql"), db.Option{})
+	if err != nil {
+		if xerrors.Is(err, db.ErrDBLocked) {
+			return xerrors.Errorf("Failed to open DB. Close DB connection before fetching. err: %w", err)
+		}
+		return xerrors.Errorf("Failed to open DB. err: %w", err)
+	}
+
+	fetchMeta, err := driver.GetFetchMeta()
+	if err != nil {
+		return xerrors.Errorf("Failed to get FetchMeta from DB. err: %w", err)
+	}
+	if fetchMeta.OutDated() {
+		return xerrors.Errorf("Failed to Insert CVEs into DB. err: SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
+	}
+	// If the fetch fails the first time (without SchemaVersion), the DB needs to be cleaned every time, so insert SchemaVersion.
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
+	}
+
+	advs, err := fortinet.FetchConvert()
+	if err != nil {
+		return xerrors.Errorf("Failed to fetch from fortinet. err: %w", err)
+	}
+
+	log.Infof("Inserting Fortinet into DB (%s).", driver.Name())
+	if err := driver.InsertFortinet(advs); err != nil {
+		return xerrors.Errorf("Failed to insert. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
+	}
+
+	fetchMeta.LastFetchedAt = time.Now()
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
+	}
+
+	log.Infof("Finished fetching Fortinet.")
+	return nil
+}

--- a/commands/server.go
+++ b/commands/server.go
@@ -64,11 +64,19 @@ func executeServer(_ *cobra.Command, _ []string) (err error) {
 	}
 	count += jvnCount
 
+	fortinetCount, err := driver.CountFortinet()
+	if err != nil {
+		log.Errorf("Failed to count Fortinet table: %s", err)
+		return err
+	}
+	count += fortinetCount
+
 	if count == 0 {
-		log.Infof("No Vulnerability data found. Run the below command to fetch data from NVD, JVN")
+		log.Infof("No Vulnerability data found. Run the below command to fetch data from NVD, JVN, Fortinet")
 		log.Infof("")
 		log.Infof(" go-cve-dictionary fetch nvd")
 		log.Infof(" go-cve-dictionary fetch jvn")
+		log.Infof(" go-cve-dictionary fetch fortinet")
 		log.Infof("")
 		return nil
 	}

--- a/db/db.go
+++ b/db/db.go
@@ -29,12 +29,14 @@ type DB interface {
 
 	Get(string) (*models.CveDetail, error)
 	GetMulti([]string) (map[string]models.CveDetail, error)
-	GetCveIDsByCpeURI(string) ([]string, []string, error)
+	GetCveIDsByCpeURI(string) ([]string, []string, []string, error)
 	GetByCpeURI(string) ([]models.CveDetail, error)
 	InsertJvn([]string) error
 	InsertNvd([]string) error
+	InsertFortinet([]models.Fortinet) error
 	CountNvd() (int, error)
 	CountJvn() (int, error)
+	CountFortinet() (int, error)
 }
 
 // Option :
@@ -306,45 +308,75 @@ func matchRpmVer(specifiedVer string, cpeInNvd models.CpeBase) bool {
 	return true
 }
 
-func matchCpe(uri string, cve *models.CveDetail) (nvdMatch, jvnMatch bool, err error) {
-	for _, nvd := range cve.Nvds {
-		for _, cpe := range nvd.Cpes {
-			isExactMatch, isRoughMatch, isVendorProductMatch, err := match(uri, cpe.CpeBase)
-			if err != nil {
-				log.Debugf("Failed to match: %s", err)
-				continue
+func matchCpe(uri string, cve *models.CveDetail) (nvdMatch, jvnMatch, fortinetMatch bool, err error) {
+	nvdMatch = false
+	if cve.HasNvd() {
+		for _, nvd := range cve.Nvds {
+			for _, cpe := range nvd.Cpes {
+				isExactMatch, isRoughMatch, isVendorProductMatch, err := match(uri, cpe.CpeBase)
+				if err != nil {
+					log.Debugf("Failed to match: %s", err)
+					continue
+				}
+				if isExactMatch || isRoughMatch || isVendorProductMatch {
+					nvdMatch = true
+					break
+				}
 			}
-			if isExactMatch || isRoughMatch || isVendorProductMatch {
-				return true, false, nil
-			}
-		}
-	}
-
-	if !cve.HasJvn() {
-		return false, false, nil
-	}
-
-	// CPE that exists only in JVN is also detected.
-	// There is a possibility of false positives since the JVN does not contain version information.
-	for _, jvn := range cve.Jvns {
-		for _, jvnCpe := range jvn.Cpes {
-			// If NVD has data of the same `part`, `vendor`, and `product`, NVD is used in priority.
-			// Because NVD has version information, but JVN does not.
-			if isCpeURIAlsoDefinedInNvd(jvnCpe.URI, cve.Nvds) {
-				continue
-			}
-
-			ok, err := isSamePartVendorProduct(uri, jvnCpe.URI)
-			if err != nil {
-				continue
-			}
-			if ok {
-				return false, true, nil
+			if nvdMatch {
+				break
 			}
 		}
 	}
 
-	return false, false, nil
+	jvnMatch = false
+	if cve.HasJvn() {
+		// CPE that exists only in JVN is also detected.
+		// There is a possibility of false positives since the JVN does not contain version information.
+		for _, jvn := range cve.Jvns {
+			for _, jvnCpe := range jvn.Cpes {
+				// If NVD has data of the same `part`, `vendor`, and `product`, NVD is used in priority.
+				// Because NVD has version information, but JVN does not.
+				if isCpeURIAlsoDefinedInNvd(jvnCpe.URI, cve.Nvds) {
+					continue
+				}
+
+				ok, err := isSamePartVendorProduct(uri, jvnCpe.URI)
+				if err != nil {
+					continue
+				}
+				if ok {
+					jvnMatch = true
+					break
+				}
+			}
+			if jvnMatch {
+				break
+			}
+		}
+	}
+
+	fortinetMatch = false
+	if cve.HasFortinet() {
+		for _, fortinet := range cve.Fortinets {
+			for _, cpe := range fortinet.Cpes {
+				isExactMatch, isRoughMatch, isVendorProductMatch, err := match(uri, cpe.CpeBase)
+				if err != nil {
+					log.Debugf("Failed to match: %s", err)
+					continue
+				}
+				if isExactMatch || isRoughMatch || isVendorProductMatch {
+					fortinetMatch = true
+					break
+				}
+			}
+			if fortinetMatch {
+				break
+			}
+		}
+	}
+
+	return nvdMatch, jvnMatch, fortinetMatch, nil
 }
 
 func isSuperORSubset(source, target common.WellFormedName) bool {
@@ -409,6 +441,28 @@ func filterCveDetailByCpeURI(uri string, d *models.CveDetail) error {
 			if matched {
 				jvn.DetectionMethod = models.JvnVendorProductMatch
 				d.Jvns = append(d.Jvns, jvn)
+				break
+			}
+		}
+	}
+
+	fortinets := append([]models.Fortinet{}, d.Fortinets...)
+	d.Fortinets = []models.Fortinet{}
+	for _, fortinet := range fortinets {
+		for _, cpe := range fortinet.Cpes {
+			isExactMatch, isRoughMatch, isVendorProductMatch, err := match(uri, cpe.CpeBase)
+			if err != nil {
+				log.Debugf("Failed to match. err: %s, uri: %s, CpeBase: %#v", err, uri, cpe.CpeBase)
+			}
+			if isExactMatch {
+				fortinet.DetectionMethod = models.FortinetExactVersionMatch
+			} else if isRoughMatch {
+				fortinet.DetectionMethod = models.FortinetRoughVersionMatch
+			} else if isVendorProductMatch {
+				fortinet.DetectionMethod = models.FortinetVendorProductMatch
+			}
+			if isExactMatch || isRoughMatch || isVendorProductMatch {
+				d.Fortinets = append(d.Fortinets, fortinet)
 				break
 			}
 		}

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -370,11 +370,12 @@ func Test_matchCpe(t *testing.T) {
 		cve *models.CveDetail
 	}
 	tests := []struct {
-		name    string
-		args    args
-		nvdWant bool
-		jvnWant bool
-		wantErr bool
+		name         string
+		args         args
+		nvdWant      bool
+		jvnWant      bool
+		fortinetWant bool
+		wantErr      bool
 	}{
 		{
 			name: "nvd range match semver",
@@ -475,10 +476,62 @@ func Test_matchCpe(t *testing.T) {
 			jvnWant: false,
 			wantErr: false,
 		},
+		{
+			name: "NVD, JVN, Fortinet all match",
+			args: args{
+				uri: "cpe:/o:fortinet:fortios:4.0.0",
+				cve: &models.CveDetail{
+					Nvds: []models.Nvd{{
+						Cpes: []models.NvdCpe{{
+							CpeBase: models.CpeBase{
+								URI: "cpe:/o:fortinet:fortios",
+								CpeWFN: models.CpeWFN{
+									Part:    "o",
+									Vendor:  "fortinet",
+									Product: "fortios",
+								},
+								VersionStartIncluding: "4.0.0",
+								VersionEndIncluding:   "4.0.1",
+							},
+						}},
+					}},
+					Jvns: []models.Jvn{{
+						Cpes: []models.JvnCpe{{
+							CpeBase: models.CpeBase{
+								URI: "cpe:/o:fortinet:fortios",
+								CpeWFN: models.CpeWFN{
+									Part:    "o",
+									Vendor:  "fortinet",
+									Product: "fortios",
+								},
+							},
+						}},
+					}},
+					Fortinets: []models.Fortinet{{
+						Cpes: []models.FortinetCpe{{
+							CpeBase: models.CpeBase{
+								URI: "cpe:/o:fortinet:fortios",
+								CpeWFN: models.CpeWFN{
+									Part:    "o",
+									Vendor:  "fortinet",
+									Product: "fortios",
+								},
+								VersionStartIncluding: "4.0.0",
+								VersionEndIncluding:   "4.0.2",
+							},
+						}},
+					}},
+				},
+			},
+			nvdWant:      true,
+			jvnWant:      false,
+			fortinetWant: true,
+			wantErr:      false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			nvdGot, jvnGot, err := matchCpe(tt.args.uri, tt.args.cve)
+			nvdGot, jvnGot, fortinetGot, err := matchCpe(tt.args.uri, tt.args.cve)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("%s error = %v, wantErr %v", tt.name, err, tt.wantErr)
 				return
@@ -488,6 +541,9 @@ func Test_matchCpe(t *testing.T) {
 			}
 			if jvnGot != tt.jvnWant {
 				t.Errorf("%s matchCpe() jvn = %v, want %v", tt.name, jvnGot, tt.jvnWant)
+			}
+			if fortinetGot != tt.fortinetWant {
+				t.Errorf("%s matchCpe() fortinet = %v, want %v", tt.name, fortinetGot, tt.fortinetWant)
 			}
 		})
 	}
@@ -547,7 +603,8 @@ func Test_filterCveDetailByCpeURI1(t *testing.T) {
 						DetectionMethod: models.NvdExactVersionMatch,
 					},
 				},
-				Jvns: []models.Jvn{},
+				Jvns:      []models.Jvn{},
+				Fortinets: []models.Fortinet{},
 			},
 		},
 		{
@@ -587,7 +644,8 @@ func Test_filterCveDetailByCpeURI1(t *testing.T) {
 						DetectionMethod: models.NvdVendorProductMatch,
 					},
 				},
-				Jvns: []models.Jvn{},
+				Jvns:      []models.Jvn{},
+				Fortinets: []models.Fortinet{},
 			},
 		},
 		{
@@ -613,7 +671,8 @@ func Test_filterCveDetailByCpeURI1(t *testing.T) {
 						DetectionMethod: models.NvdVendorProductMatch,
 					},
 				},
-				Jvns: []models.Jvn{},
+				Jvns:      []models.Jvn{},
+				Fortinets: []models.Fortinet{},
 			},
 		},
 		{
@@ -635,8 +694,9 @@ func Test_filterCveDetailByCpeURI1(t *testing.T) {
 				},
 			},
 			expected: &models.CveDetail{
-				Nvds: []models.Nvd{},
-				Jvns: []models.Jvn{},
+				Nvds:      []models.Nvd{},
+				Jvns:      []models.Jvn{},
+				Fortinets: []models.Fortinet{},
 			},
 		},
 		{
@@ -655,7 +715,8 @@ func Test_filterCveDetailByCpeURI1(t *testing.T) {
 						DetectionMethod: models.NvdRoughVersionMatch,
 					},
 				},
-				Jvns: []models.Jvn{},
+				Jvns:      []models.Jvn{},
+				Fortinets: []models.Fortinet{},
 			},
 		},
 		{
@@ -668,8 +729,9 @@ func Test_filterCveDetailByCpeURI1(t *testing.T) {
 				},
 			},
 			expected: &models.CveDetail{
-				Nvds: []models.Nvd{},
-				Jvns: []models.Jvn{},
+				Nvds:      []models.Nvd{},
+				Jvns:      []models.Jvn{},
+				Fortinets: []models.Fortinet{},
 			},
 		},
 		{
@@ -688,7 +750,8 @@ func Test_filterCveDetailByCpeURI1(t *testing.T) {
 						DetectionMethod: models.NvdExactVersionMatch,
 					},
 				},
-				Jvns: []models.Jvn{},
+				Jvns:      []models.Jvn{},
+				Fortinets: []models.Fortinet{},
 			},
 		},
 		{
@@ -701,8 +764,9 @@ func Test_filterCveDetailByCpeURI1(t *testing.T) {
 				},
 			},
 			expected: &models.CveDetail{
-				Nvds: []models.Nvd{},
-				Jvns: []models.Jvn{},
+				Nvds:      []models.Nvd{},
+				Jvns:      []models.Jvn{},
+				Fortinets: []models.Fortinet{},
 			},
 		},
 		{
@@ -716,8 +780,31 @@ func Test_filterCveDetailByCpeURI1(t *testing.T) {
 				},
 			},
 			expected: &models.CveDetail{
-				Nvds: []models.Nvd{},
+				Nvds:      []models.Nvd{},
+				Jvns:      []models.Jvn{},
+				Fortinets: []models.Fortinet{},
+			},
+		},
+		{
+			name: "NVD, JVN, Fortinet all match",
+			args: args{
+				uri: "cpe:/o:fortinet:fortios:4.0.0",
+				cve: &models.CveDetail{
+					Nvds:      []models.Nvd{{Cpes: []models.NvdCpe{{CpeBase: models.CpeBase{URI: "cpe:/o:fortinet:fortios:4.0.0"}}}}},
+					Jvns:      []models.Jvn{{Cpes: []models.JvnCpe{{CpeBase: models.CpeBase{URI: "cpe:/o:fortinet:fortios"}}}}},
+					Fortinets: []models.Fortinet{{Cpes: []models.FortinetCpe{{CpeBase: models.CpeBase{URI: "cpe:/o:fortinet:fortios:4.0.0"}}}}},
+				},
+			},
+			expected: &models.CveDetail{
+				Nvds: []models.Nvd{{
+					Cpes:            []models.NvdCpe{{CpeBase: models.CpeBase{URI: "cpe:/o:fortinet:fortios:4.0.0"}}},
+					DetectionMethod: models.NvdExactVersionMatch,
+				}},
 				Jvns: []models.Jvn{},
+				Fortinets: []models.Fortinet{{
+					Cpes:            []models.FortinetCpe{{CpeBase: models.CpeBase{URI: "cpe:/o:fortinet:fortios:4.0.0"}}},
+					DetectionMethod: models.FortinetExactVersionMatch,
+				}},
 			},
 		},
 	}

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -14,16 +14,17 @@ import (
 	"github.com/knqyf263/go-cpe/common"
 	"github.com/knqyf263/go-cpe/naming"
 	"github.com/spf13/viper"
-	"github.com/vulsio/go-cve-dictionary/config"
-	"github.com/vulsio/go-cve-dictionary/fetcher/jvn"
-	"github.com/vulsio/go-cve-dictionary/fetcher/nvd"
-	logger "github.com/vulsio/go-cve-dictionary/log"
-	"github.com/vulsio/go-cve-dictionary/models"
 	"golang.org/x/xerrors"
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	gormLogger "gorm.io/gorm/logger"
+
+	"github.com/vulsio/go-cve-dictionary/config"
+	"github.com/vulsio/go-cve-dictionary/fetcher/jvn"
+	"github.com/vulsio/go-cve-dictionary/fetcher/nvd"
+	logger "github.com/vulsio/go-cve-dictionary/log"
+	"github.com/vulsio/go-cve-dictionary/models"
 )
 
 // Supported DB dialects.
@@ -159,6 +160,12 @@ func (r *RDBDriver) MigrateDB() error {
 		&models.JvnCpe{},
 		&models.JvnReference{},
 		&models.JvnCert{},
+
+		&models.Fortinet{},
+		&models.FortinetCvss3{},
+		&models.FortinetCwe{},
+		&models.FortinetCpe{},
+		&models.FortinetReference{},
 	); err != nil {
 		switch r.name {
 		case dialectSqlite3:
@@ -288,6 +295,16 @@ func (r *RDBDriver) Get(cveID string) (*models.CveDetail, error) {
 		return nil, xerrors.Errorf("Failed to fill Jvn. Jvn{CveID: %s} err: %w", cveID, err)
 	}
 
+	if err := r.conn.
+		Where(&models.Fortinet{CveID: cveID}).
+		Preload("Cvss3").
+		Preload("Cwes").
+		Preload("Cpes").
+		Preload("References").
+		Find(&detail.Fortinets).Error; err != nil {
+		return nil, xerrors.Errorf("Failed to fill Fortinet. Fortinet{CveID: %s} err: %w", cveID, err)
+	}
+
 	return &detail, nil
 }
 
@@ -319,6 +336,15 @@ func (r *RDBDriver) getCveIDsByPartVendorProduct(uri string) ([]string, error) {
 		return nil, err
 	}
 
+	fortinets := []models.Fortinet{}
+	if err := r.conn.
+		Select("fortinets.cve_id").
+		Joins("JOIN fortinet_cpes ON fortinet_cpes.fortinet_id = fortinets.id").
+		Where("fortinet_cpes.part = ? AND fortinet_cpes.vendor = ? AND fortinet_cpes.product = ?", part, vendor, product).
+		Find(&fortinets).Error; err != nil {
+		return nil, err
+	}
+
 	cveIDs := []string{}
 	for _, nvd := range nvds {
 		cveIDs = append(cveIDs, nvd.CveID)
@@ -326,15 +352,18 @@ func (r *RDBDriver) getCveIDsByPartVendorProduct(uri string) ([]string, error) {
 	for _, jvn := range jvns {
 		cveIDs = append(cveIDs, jvn.CveID)
 	}
+	for _, fortinet := range fortinets {
+		cveIDs = append(cveIDs, fortinet.CveID)
+	}
 
 	return cveIDs, nil
 }
 
 // GetCveIDsByCpeURI Select Cve Ids by by pseudo-CPE
-func (r *RDBDriver) GetCveIDsByCpeURI(uri string) (nvdCveIDs []string, jvnCveIDs []string, err error) {
+func (r *RDBDriver) GetCveIDsByCpeURI(uri string) (nvdCveIDs []string, jvnCveIDs []string, fortinetCveIDs []string, err error) {
 	cveIDs, err := r.getCveIDsByPartVendorProduct(uri)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	uniqCveIDs := map[string]bool{}
@@ -344,28 +373,34 @@ func (r *RDBDriver) GetCveIDsByCpeURI(uri string) (nvdCveIDs []string, jvnCveIDs
 
 	nvdCveIDs = []string{}
 	jvnCveIDs = []string{}
+	fortinetCveIDs = []string{}
 	for cveID := range uniqCveIDs {
 		d, err := r.Get(cveID)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		if err := filterCveDetailByCpeURI(uri, d); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
-		nvdMatch, jvnMatch, err := matchCpe(uri, d)
+		nvdMatch, jvnMatch, fortinetMatch, err := matchCpe(uri, d)
 		if err != nil {
 			logger.Warnf("Failed to compare the version:%s %s %#v",
 				err, uri, d)
 			continue
 		}
+
 		if nvdMatch {
 			nvdCveIDs = append(nvdCveIDs, d.CveID)
-		} else if jvnMatch {
+		}
+		if jvnMatch && !nvdMatch {
 			jvnCveIDs = append(jvnCveIDs, d.CveID)
+		}
+		if fortinetMatch {
+			fortinetCveIDs = append(fortinetCveIDs, d.CveID)
 		}
 	}
 
-	return nvdCveIDs, jvnCveIDs, nil
+	return nvdCveIDs, jvnCveIDs, fortinetCveIDs, nil
 }
 
 // GetByCpeURI Select Cve information from DB.
@@ -389,7 +424,7 @@ func (r *RDBDriver) GetByCpeURI(uri string) ([]models.CveDetail, error) {
 		if err := filterCveDetailByCpeURI(uri, d); err != nil {
 			return nil, err
 		}
-		if len(d.Nvds) > 0 || len(d.Jvns) > 0 {
+		if len(d.Nvds) > 0 || len(d.Jvns) > 0 || len(d.Fortinets) > 0 {
 			details = append(details, *d)
 		}
 	}
@@ -603,5 +638,73 @@ func insertNvd(tx *gorm.DB, cves []models.Nvd, batchSize int) error {
 	}
 	bar.Finish()
 
+	return nil
+}
+
+// CountFortinet count fortinet table
+func (r *RDBDriver) CountFortinet() (int, error) {
+	var count int64
+	if err := r.conn.Model(&models.Fortinet{}).Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return int(count), nil
+}
+
+// InsertFortinet Cve information from DB.
+func (r *RDBDriver) InsertFortinet(advs []models.Fortinet) (err error) {
+	tx := r.conn.Begin()
+	defer func() {
+		if re := recover(); re != nil {
+			tx.Rollback()
+		}
+	}()
+	if err := tx.Error; err != nil {
+		return err
+	}
+
+	batchSize := viper.GetInt("batch-size")
+	if batchSize < 1 {
+		return fmt.Errorf("Failed to set batch-size. err: batch-size option is not set properly")
+	}
+
+	logger.Infof("Deleting Fortinet tables...")
+	if err := deleteFortinet(tx); err != nil {
+		tx.Rollback()
+		return xerrors.Errorf("Failed to deleteFortinet. err: %w", err)
+	}
+
+	logger.Infof("Inserting fetched %d CVEs...", len(advs))
+	bar := pb.StartNew(len(advs))
+	for _, adv := range advs {
+		if err := tx.Omit("Cpes").Create(&adv).Error; err != nil {
+			return xerrors.Errorf("Failed to insert. err: %w", err)
+		}
+
+		for i := range adv.Cpes {
+			adv.Cpes[i].FortinetID = uint(adv.ID)
+		}
+
+		for idx := range chunkSlice(len(adv.Cpes), batchSize) {
+			if err := tx.Create(adv.Cpes[idx.From:idx.To]).Error; err != nil {
+				return xerrors.Errorf("Failed to insert. err: %w", err)
+			}
+		}
+		bar.Increment()
+	}
+	bar.Finish()
+	logger.Infof("Refreshed %d CVEs.", len(advs))
+
+	if err := tx.Commit().Error; err != nil {
+		return xerrors.Errorf("Failed to Commit Transaction. err: %w", err)
+	}
+	return nil
+}
+
+func deleteFortinet(tx *gorm.DB) error {
+	for _, table := range []interface{}{models.Fortinet{}, models.FortinetCvss3{}, models.FortinetCwe{}, models.FortinetCpe{}, models.FortinetReference{}} {
+		if err := tx.Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(table).Error; err != nil {
+			return xerrors.Errorf("Failed to delete old records. err: %w", err)
+		}
+	}
 	return nil
 }

--- a/db/redis.go
+++ b/db/redis.go
@@ -14,12 +14,13 @@ import (
 	"github.com/knqyf263/go-cpe/common"
 	"github.com/knqyf263/go-cpe/naming"
 	"github.com/spf13/viper"
+	"golang.org/x/xerrors"
+
 	"github.com/vulsio/go-cve-dictionary/config"
 	"github.com/vulsio/go-cve-dictionary/fetcher/jvn"
 	"github.com/vulsio/go-cve-dictionary/fetcher/nvd"
 	log "github.com/vulsio/go-cve-dictionary/log"
 	"github.com/vulsio/go-cve-dictionary/models"
-	"golang.org/x/xerrors"
 )
 
 /**
@@ -34,20 +35,20 @@ import (
   └─────────────────────────────────────────┴──────────────────────┴───────────────────────────────────────────────────┘
 
 - Hash
-  ┌──────────────────┬───────────────┬─────────────┬──────────────────────────────────────────────────┐
-  │     HASH         │      FIELD    │    VALUE    │             PURPOSE                              │
-  └──────────────────┴───────────────┴─────────────┴──────────────────────────────────────────────────┘
-  ┌──────────────────┬───────────────┬─────────────┬──────────────────────────────────────────────────┐
-  │ CVE#CVE#${CVEID} │ NVD/${JVNID}  │ ${CVEJSON}  │ Get CVEJSON by CVEID                             │
-  ├──────────────────┼───────────────┼─────────────┼──────────────────────────────────────────────────┤
-  │ CVE#DEP          │ NVD/JVN       │    JSON     │ TO DELETE OUTDATED AND UNNEEDED FIELD AND MEMBER │
-  ├──────────────────┼───────────────┼─────────────┼──────────────────────────────────────────────────┤
-  │ CVE#FETCHMETA    │ Revision      │ string      │ Get Go-Cve-Dictionary Binary Revision            │
-  ├──────────────────┼───────────────┼─────────────┼──────────────────────────────────────────────────┤
-  │ CVE#FETCHMETA    │ SchemaVersion │ uint        │ Get Go-Cve-Dictionary Schema Version             │
-  ├──────────────────┼───────────────┼─────────────┼──────────────────────────────────────────────────┤
-  │ CVE#FETCHMETA    │ LastFetchedAt │ time.Time   │ Get Go-Cve-Dictionary Last Fetched Time          │
-  └──────────────────┴───────────────┴─────────────┴──────────────────────────────────────────────────┘
+  ┌──────────────────┬────────────────────────────┬──────────────┬──────────────────────────────────────────────────┐
+  │     HASH         │             FIELD          │    VALUE     │                    PURPOSE                       │
+  └──────────────────┴────────────────────────────┴──────────────┴──────────────────────────────────────────────────┘
+  ┌──────────────────┬────────────────────────────┬──────────────┬──────────────────────────────────────────────────┐
+  │ CVE#CVE#${CVEID} │ NVD/${JVNID}/${FortinetID} │ ${CVEJSON}   │ Get CVEJSON by CVEID                             │
+  ├──────────────────┼────────────────────────────┼──────────────┼──────────────────────────────────────────────────┤
+  │ CVE#DEP          │ NVD/JVN/Fortinet           │    JSON      │ TO DELETE OUTDATED AND UNNEEDED FIELD AND MEMBER │
+  ├──────────────────┼────────────────────────────┼──────────────┼──────────────────────────────────────────────────┤
+  │ CVE#FETCHMETA    │ Revision                   │ string       │ Get Go-Cve-Dictionary Binary Revision            │
+  ├──────────────────┼────────────────────────────┼──────────────┼──────────────────────────────────────────────────┤
+  │ CVE#FETCHMETA    │ SchemaVersion              │ uint         │ Get Go-Cve-Dictionary Schema Version             │
+  ├──────────────────┼────────────────────────────┼──────────────┼──────────────────────────────────────────────────┤
+  │ CVE#FETCHMETA    │ LastFetchedAt              │ time.Time    │ Get Go-Cve-Dictionary Last Fetched Time          │
+  └──────────────────┴────────────────────────────┴──────────────┴──────────────────────────────────────────────────┘
 
 **/
 
@@ -191,31 +192,35 @@ func (r *RedisDriver) Get(cveID string) (*models.CveDetail, error) {
 
 func convertToCveDetail(cveID string, results map[string]string) (models.CveDetail, error) {
 	detail := models.CveDetail{
-		CveID: cveID,
-		Nvds:  []models.Nvd{},
-		Jvns:  []models.Jvn{},
-	}
-
-	if jsonStr, ok := results[models.NvdType]; ok {
-		var nvd models.Nvd
-		if err := json.Unmarshal([]byte(jsonStr), &nvd); err != nil {
-			return models.CveDetail{}, xerrors.Errorf("Failed to Unmarshal JSON. err: %w", err)
-		}
-		detail.Nvds = append(detail.Nvds, nvd)
-		delete(results, models.NvdType)
+		CveID:     cveID,
+		Nvds:      []models.Nvd{},
+		Jvns:      []models.Jvn{},
+		Fortinets: []models.Fortinet{},
 	}
 
 	for field, jsonStr := range results {
-		if !strings.HasPrefix(field, "JVNDB-") {
-			log.Warnf("field(%s) obtained by %s is not in JVN format", field, cveID)
-			continue
+		switch {
+		case field == models.NvdType:
+			var nvd models.Nvd
+			if err := json.Unmarshal([]byte(jsonStr), &nvd); err != nil {
+				return models.CveDetail{}, xerrors.Errorf("Failed to Unmarshal JSON. err: %w", err)
+			}
+			detail.Nvds = append(detail.Nvds, nvd)
+		case strings.HasPrefix(field, "JVNDB-"):
+			var jvn models.Jvn
+			if err := json.Unmarshal([]byte(jsonStr), &jvn); err != nil {
+				return models.CveDetail{}, xerrors.Errorf("Failed to Unmarshal JSON. err: %w", err)
+			}
+			detail.Jvns = append(detail.Jvns, jvn)
+		case strings.HasPrefix(field, "FG-IR-"):
+			var fortinet models.Fortinet
+			if err := json.Unmarshal([]byte(jsonStr), &fortinet); err != nil {
+				return models.CveDetail{}, xerrors.Errorf("Failed to Unmarshal JSON. err: %w", err)
+			}
+			detail.Fortinets = append(detail.Fortinets, fortinet)
+		default:
+			log.Warnf("field(%s) obtained by %s is not in NVD, JVN, Fortinet format", field, cveID)
 		}
-
-		var jvn models.Jvn
-		if err := json.Unmarshal([]byte(jsonStr), &jvn); err != nil {
-			return models.CveDetail{}, xerrors.Errorf("Failed to Unmarshal JSON. err: %w", err)
-		}
-		detail.Jvns = append(detail.Jvns, jvn)
 	}
 
 	return detail, nil
@@ -251,43 +256,49 @@ func (r *RedisDriver) GetMulti(cveIDs []string) (map[string]models.CveDetail, er
 }
 
 // GetCveIDsByCpeURI Select Cve Ids by by pseudo-CPE
-func (r *RedisDriver) GetCveIDsByCpeURI(uri string) ([]string, []string, error) {
+func (r *RedisDriver) GetCveIDsByCpeURI(uri string) ([]string, []string, []string, error) {
 	specified, err := naming.UnbindURI(uri)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	cpeKey := fmt.Sprintf(cpeKeyFormat, fmt.Sprintf("%s#%s#%s", specified.Get(common.AttributePart), specified.Get(common.AttributeVendor), specified.Get(common.AttributeProduct)))
 
 	cveIDs, err := r.conn.SMembers(context.Background(), cpeKey).Result()
 	if err != nil {
-		return nil, nil, xerrors.Errorf("Failed to SMembers. err: %w", err)
+		return nil, nil, nil, xerrors.Errorf("Failed to SMembers. err: %w", err)
 	}
 
 	cveDetails, err := r.GetMulti(cveIDs)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("Failed to GetMulti. err: %w", err)
+		return nil, nil, nil, xerrors.Errorf("Failed to GetMulti. err: %w", err)
 	}
 
 	nvdCveIDs := []string{}
 	jvnCveIDs := []string{}
+	fortinetCveIDs := []string{}
 	for _, detail := range cveDetails {
 		if err := filterCveDetailByCpeURI(uri, &detail); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
-		nvdMatch, jvnMatch, err := matchCpe(uri, &detail)
+		nvdMatch, jvnMatch, fortinetMatch, err := matchCpe(uri, &detail)
 		if err != nil {
 			log.Warnf("Failed to compare the version:%s %s %#v", err, uri, &detail)
 			// continue matching
 			continue
 		}
+
 		if nvdMatch {
 			nvdCveIDs = append(nvdCveIDs, detail.CveID)
-		} else if jvnMatch {
+		}
+		if jvnMatch && !nvdMatch {
 			jvnCveIDs = append(jvnCveIDs, detail.CveID)
+		}
+		if fortinetMatch {
+			fortinetCveIDs = append(fortinetCveIDs, detail.CveID)
 		}
 	}
 
-	return nvdCveIDs, jvnCveIDs, nil
+	return nvdCveIDs, jvnCveIDs, fortinetCveIDs, nil
 }
 
 // GetByCpeURI Select Cve information from DB.
@@ -313,7 +324,7 @@ func (r *RedisDriver) GetByCpeURI(uri string) ([]models.CveDetail, error) {
 		if err := filterCveDetailByCpeURI(uri, &detail); err != nil {
 			return nil, err
 		}
-		if len(detail.Nvds) > 0 || len(detail.Jvns) > 0 {
+		if len(detail.Nvds) > 0 || len(detail.Jvns) > 0 || len(detail.Fortinets) > 0 {
 			details = append(details, detail)
 		}
 	}
@@ -332,12 +343,17 @@ func (r *RedisDriver) CountJvn() (int, error) {
 	}
 
 	// deps: {"JVNID": {"CVEID": {"part#vendor#product": {}}}}
-	var deps map[string]map[string]struct{}
+	var deps map[string]map[string]map[string]struct{}
 	if err := json.Unmarshal([]byte(depstr), &deps); err != nil {
 		return 0, xerrors.Errorf("Failed to unmarshal JSON. err: %w", err)
 	}
 
-	return len(deps), nil
+	count := 0
+	for _, cs := range deps {
+		count += len(cs)
+	}
+
+	return count, nil
 }
 
 // InsertJvn insert items fetched from JVN.
@@ -578,6 +594,121 @@ func (r *RedisDriver) InsertNvd(years []string) error {
 		return xerrors.Errorf("Failed to Marshal JSON. err: %w", err)
 	}
 	_ = pipe.HSet(ctx, depKey, models.NvdType, string(newDepsJSON))
+	if _, err = pipe.Exec(ctx); err != nil {
+		return xerrors.Errorf("Failed to exec pipeline. err: %w", err)
+	}
+
+	return nil
+}
+
+// CountFortinet count fortinet table
+func (r *RedisDriver) CountFortinet() (int, error) {
+	depstr, err := r.conn.HGet(context.Background(), depKey, models.FortinetType).Result()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return 0, nil
+		}
+		return 0, err
+	}
+
+	// deps: {"FortinetID": {"CVEID": {"part#vendor#product": {}}}}
+	var deps map[string]map[string]map[string]struct{}
+	if err := json.Unmarshal([]byte(depstr), &deps); err != nil {
+		return 0, xerrors.Errorf("Failed to unmarshal JSON. err: %w", err)
+	}
+
+	count := 0
+	for _, cs := range deps {
+		count += len(cs)
+	}
+
+	return count, nil
+}
+
+// InsertFortinet Cve information from DB.
+func (r *RedisDriver) InsertFortinet(advs []models.Fortinet) error {
+	ctx := context.Background()
+	batchSize := viper.GetInt("batch-size")
+	if batchSize < 1 {
+		return fmt.Errorf("Failed to set batch-size. err: batch-size option is not set properly")
+	}
+	var err error
+
+	// newDeps, oldDeps: {"FortinetID": {"CVEID": {"part#vendor#product": {}}}}
+	newDeps := map[string]map[string]map[string]struct{}{}
+	oldDepsStr, err := r.conn.HGet(ctx, depKey, models.FortinetType).Result()
+	if err != nil {
+		if !errors.Is(err, redis.Nil) {
+			return xerrors.Errorf("Failed to Get key: %s. err: %w", depKey, err)
+		}
+		oldDepsStr = "{}"
+	}
+	var oldDeps map[string]map[string]map[string]struct{}
+	if err := json.Unmarshal([]byte(oldDepsStr), &oldDeps); err != nil {
+		return xerrors.Errorf("Failed to unmarshal JSON. err: %w", err)
+	}
+
+	log.Infof("Inserting fetched %d CVEs...", len(advs))
+	bar := pb.StartNew(len(advs))
+	for idx := range chunkSlice(len(advs), batchSize) {
+		pipe := r.conn.Pipeline()
+		for _, adv := range advs[idx.From:idx.To] {
+			var jn []byte
+			if jn, err = json.Marshal(adv); err != nil {
+				return xerrors.Errorf("Failed to marshal json. err: %w", err)
+			}
+			_ = pipe.HSet(ctx, fmt.Sprintf(cveKeyFormat, adv.CveID), adv.AdvisoryID, string(jn))
+			if _, ok := newDeps[adv.AdvisoryID]; !ok {
+				newDeps[adv.AdvisoryID] = map[string]map[string]struct{}{}
+			}
+			if _, ok := newDeps[adv.AdvisoryID][adv.CveID]; !ok {
+				newDeps[adv.AdvisoryID][adv.CveID] = map[string]struct{}{}
+			}
+			for _, cpe := range adv.Cpes {
+				cpePartVendorProductStr := fmt.Sprintf("%s#%s#%s", cpe.Part, cpe.Vendor, cpe.Product)
+				_ = pipe.SAdd(ctx, fmt.Sprintf(cpeKeyFormat, cpePartVendorProductStr), adv.CveID)
+				newDeps[adv.AdvisoryID][adv.CveID][cpePartVendorProductStr] = struct{}{}
+				if _, ok := oldDeps[adv.AdvisoryID]; ok {
+					if _, ok := oldDeps[adv.AdvisoryID][adv.CveID]; ok {
+						delete(oldDeps[adv.AdvisoryID][adv.CveID], cpePartVendorProductStr)
+						if len(oldDeps[adv.AdvisoryID][adv.CveID]) == 0 {
+							delete(oldDeps[adv.AdvisoryID], adv.CveID)
+						}
+					}
+				}
+			}
+			if _, ok := oldDeps[adv.AdvisoryID]; ok {
+				if len(oldDeps[adv.AdvisoryID]) == 0 {
+					delete(oldDeps, adv.AdvisoryID)
+				}
+			}
+		}
+		if _, err = pipe.Exec(ctx); err != nil {
+			return xerrors.Errorf("Failed to exec pipeline. err: %w", err)
+		}
+		bar.Add(idx.To - idx.From)
+	}
+	bar.Finish()
+	log.Infof("Refreshed %d CVEs.", len(advs))
+
+	pipe := r.conn.Pipeline()
+	for fortinetID, cves := range oldDeps {
+		for cveID, cpes := range cves {
+			for cpePartVendorProductStr := range cpes {
+				_ = pipe.SRem(ctx, fmt.Sprintf(cpeKeyFormat, cpePartVendorProductStr), cveID)
+			}
+			if _, ok := newDeps[fortinetID]; !ok {
+				if _, ok := newDeps[fortinetID][cveID]; !ok {
+					_ = pipe.HDel(ctx, fmt.Sprintf(cveKeyFormat, cveID), fortinetID)
+				}
+			}
+		}
+	}
+	newDepsJSON, err := json.Marshal(newDeps)
+	if err != nil {
+		return xerrors.Errorf("Failed to Marshal JSON. err: %w", err)
+	}
+	_ = pipe.HSet(ctx, depKey, models.FortinetType, string(newDepsJSON))
 	if _, err = pipe.Exec(ctx); err != nil {
 		return xerrors.Errorf("Failed to exec pipeline. err: %w", err)
 	}

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"crypto/tls"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -15,7 +15,7 @@ import (
 	"golang.org/x/xerrors"
 )
 
-//FetchFeedFile fetches vulnerability feed file concurrently
+// FetchFeedFile fetches vulnerability feed file concurrently
 func FetchFeedFile(urlstr string, gzip bool) (body []byte, err error) {
 	log.Infof("Fetching... %s", urlstr)
 
@@ -75,7 +75,7 @@ func fetchFile(urlstr string, isGzip bool) (body []byte, err error) {
 	}
 
 	defer resp.Body.Close()
-	buf, err := ioutil.ReadAll(resp.Body)
+	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, xerrors.Errorf("Failed to read body. url: %s, err: %w", urlstr, err)
 	}
@@ -91,7 +91,7 @@ func fetchFile(urlstr string, isGzip bool) (body []byte, err error) {
 			return nil, xerrors.Errorf("Failed to decompress NVD feedfile. url: %s, err: %w", urlstr, err)
 		}
 
-		bytes, err := ioutil.ReadAll(reader)
+		bytes, err := io.ReadAll(reader)
 		if err != nil {
 			return nil, xerrors.Errorf("Failed to Read NVD feedfile. url: %s, err: %w", urlstr, err)
 		}

--- a/fetcher/fortinet/fortinet.go
+++ b/fetcher/fortinet/fortinet.go
@@ -1,0 +1,332 @@
+package fortinet
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/knqyf263/go-cpe/common"
+	"github.com/knqyf263/go-cpe/naming"
+	"golang.org/x/xerrors"
+
+	"github.com/vulsio/go-cve-dictionary/fetcher"
+	"github.com/vulsio/go-cve-dictionary/log"
+	"github.com/vulsio/go-cve-dictionary/models"
+)
+
+// FetchConvert Fetch CVE vulnerability information from Fortinet
+func FetchConvert() ([]models.Fortinet, error) {
+	bs, err := fetcher.FetchFeedFile("https://github.com/vulsio/vuls-data-raw-fortinet/archive/refs/heads/main.zip", false)
+	if err != nil {
+		return nil, xerrors.Errorf("Failed to fetch vulsio/vuls-data-raw-fortinet. err: %w", err)
+	}
+
+	r, err := zip.NewReader(bytes.NewReader(bs), int64(len(bs)))
+	if err != nil {
+		return nil, xerrors.Errorf("Failed to create zip reader. err: %w", err)
+	}
+
+	var advs []models.Fortinet
+	for _, zf := range r.File {
+		if zf.FileInfo().IsDir() {
+			continue
+		}
+
+		as, err := func() ([]models.Fortinet, error) {
+			f, err := zf.Open()
+			if err != nil {
+				return nil, xerrors.Errorf("Failed to open. err: %w", err)
+			}
+			defer f.Close()
+
+			var a advisory
+			if err := json.NewDecoder(f).Decode(&a); err != nil {
+				return nil, xerrors.Errorf("Failed to decode json. err: %w", err)
+			}
+
+			converted, err := convert(a)
+			if err != nil {
+				return nil, xerrors.Errorf("Failed to convert advisory. err: %w", err)
+			}
+
+			return converted, nil
+		}()
+		if err != nil {
+			return nil, xerrors.Errorf("Failed to convert %s. err: %w", zf.Name, err)
+		}
+
+		advs = append(advs, as...)
+	}
+
+	return advs, nil
+}
+
+func convert(a advisory) ([]models.Fortinet, error) {
+	converted := []models.Fortinet{}
+	for _, v := range a.Vulnerabilities {
+		if v.CVE == "" {
+			continue
+		}
+
+		cs := models.Fortinet{
+			AdvisoryID:       a.ID,
+			CveID:            v.CVE,
+			Title:            a.Title,
+			Summary:          a.Summary,
+			Descriptions:     a.Description,
+			PublishedDate:    a.Published,
+			LastModifiedDate: a.Updated,
+			AdvisoryURL:      a.AdvisoryURL,
+		}
+
+		for _, d := range v.Definitions {
+			for _, c := range d.Configurations {
+				cpes, err := cpeWalk(c)
+				if err != nil {
+					return nil, xerrors.Errorf("Failed to cpe walk. err: %w", err)
+				}
+				cs.Cpes = cpes
+			}
+
+			if d.CVSSv3 != nil {
+				parsed := parseCvss3VectorStr(d.CVSSv3.Vector)
+				cs.Cvss3 = models.FortinetCvss3{
+					Cvss3: models.Cvss3{
+						VectorString:          d.CVSSv3.Vector,
+						AttackVector:          parsed.AttackVector,
+						AttackComplexity:      parsed.AttackComplexity,
+						PrivilegesRequired:    parsed.PrivilegesRequired,
+						UserInteraction:       parsed.UserInteraction,
+						Scope:                 parsed.Scope,
+						ConfidentialityImpact: parsed.ConfidentialityImpact,
+						IntegrityImpact:       parsed.IntegrityImpact,
+						AvailabilityImpact:    parsed.AvailabilityImpact,
+					},
+				}
+				if d.CVSSv3.BaseScore != nil {
+					cs.Cvss3.Cvss3.BaseScore = *d.CVSSv3.BaseScore
+				}
+			}
+
+			for _, cwe := range d.CWE {
+				cs.Cwes = append(cs.Cwes, models.FortinetCwe{
+					CweID: cwe,
+				})
+			}
+		}
+
+		for _, r := range a.References {
+			cs.References = append(cs.References, models.FortinetReference{
+				Reference: models.Reference{
+					Name: r.Description,
+					Link: r.URL,
+				},
+			})
+		}
+
+		converted = append(converted, cs)
+	}
+	return converted, nil
+}
+
+func cpeWalk(conf configurations) ([]models.FortinetCpe, error) {
+	cpes := []models.FortinetCpe{}
+
+	for _, n := range conf.Nodes {
+		if strings.HasSuffix(n.Description, ":") || ((n.Affected.Eqaul != nil && *n.Affected.Eqaul == "") && (n.Affected.GreaterThan != nil && *n.Affected.GreaterThan == "") && (n.Affected.GreaterEqaul != nil && *n.Affected.GreaterEqaul == "") && (n.Affected.LessThan != nil && *n.Affected.LessThan == "") && (n.Affected.LessEqual != nil && *n.Affected.LessEqual == "")) {
+			continue
+		}
+
+		wfn, err := naming.UnbindFS(n.CPE)
+		if err != nil {
+			return nil, xerrors.Errorf("Failed to unbind a formatted string to WFN. err: %w", err)
+		}
+
+		if n.Affected.Eqaul != nil {
+			// n.Affected.Eqaul: 4.2.0, 5.0.0:beta1, ANY, NA
+			for i, v := range strings.Split(*n.Affected.Eqaul, ":") {
+				switch i {
+				case 0:
+					switch v {
+					case "ANY", "NA":
+						lv, err := common.NewLogicalValue(v)
+						if err != nil {
+							return nil, xerrors.Errorf("Failed to new Logicalvalue. err: %w", err)
+						}
+						if err := wfn.Set(common.AttributeVersion, lv); err != nil {
+							return nil, xerrors.Errorf("Failed to set version to WFN. err: %w", err)
+						}
+					default:
+						if err := wfn.Set(common.AttributeVersion, strings.NewReplacer(".", "\\.", "-", "\\-").Replace(v)); err != nil {
+							return nil, xerrors.Errorf("Failed to set version to WFN. err: %w", err)
+						}
+					}
+				case 1:
+					switch v {
+					case "ANY", "NA":
+						lv, err := common.NewLogicalValue(v)
+						if err != nil {
+							return nil, xerrors.Errorf("Failed to new Logicalvalue. err: %w", err)
+						}
+						if err := wfn.Set(common.AttributeUpdate, lv); err != nil {
+							return nil, xerrors.Errorf("Failed to set update to WFN. err: %w", err)
+						}
+					default:
+						if err := wfn.Set(common.AttributeUpdate, v); err != nil {
+							return nil, xerrors.Errorf("Failed to set update to WFN. err: %w", err)
+						}
+					}
+				}
+			}
+		}
+
+		cpeBase := models.CpeBase{
+			URI:             naming.BindToURI(wfn),
+			FormattedString: naming.BindToFS(wfn),
+			WellFormedName:  wfn.String(),
+			CpeWFN: models.CpeWFN{
+				Part:            fmt.Sprintf("%s", wfn.Get(common.AttributePart)),
+				Vendor:          fmt.Sprintf("%s", wfn.Get(common.AttributeVendor)),
+				Product:         fmt.Sprintf("%s", wfn.Get(common.AttributeProduct)),
+				Version:         fmt.Sprintf("%s", wfn.Get(common.AttributeVersion)),
+				Update:          fmt.Sprintf("%s", wfn.Get(common.AttributeUpdate)),
+				Edition:         fmt.Sprintf("%s", wfn.Get(common.AttributeEdition)),
+				Language:        fmt.Sprintf("%s", wfn.Get(common.AttributeLanguage)),
+				SoftwareEdition: fmt.Sprintf("%s", wfn.Get(common.AttributeSwEdition)),
+				TargetSW:        fmt.Sprintf("%s", wfn.Get(common.AttributeTargetSw)),
+				TargetHW:        fmt.Sprintf("%s", wfn.Get(common.AttributeTargetHw)),
+				Other:           fmt.Sprintf("%s", wfn.Get(common.AttributeOther)),
+			},
+		}
+
+		if n.Affected.GreaterThan != nil {
+			cpeBase.VersionStartExcluding = *n.Affected.GreaterThan
+		}
+		if n.Affected.GreaterEqaul != nil {
+			cpeBase.VersionStartIncluding = *n.Affected.GreaterEqaul
+		}
+		if n.Affected.LessThan != nil {
+			cpeBase.VersionEndExcluding = *n.Affected.LessThan
+		}
+		if n.Affected.LessEqual != nil {
+			cpeBase.VersionEndIncluding = *n.Affected.LessEqual
+		}
+
+		cpes = append(cpes, models.FortinetCpe{
+			CpeBase: cpeBase,
+		})
+	}
+
+	if conf.Children != nil {
+		cs, err := cpeWalk(*conf.Children)
+		if err != nil {
+			return nil, xerrors.Errorf("Failed to cpewalk. err: %w", err)
+		}
+		cpes = append(cpes, cs...)
+	}
+
+	return cpes, nil
+}
+
+func parseCvss3VectorStr(vector string) models.Cvss3 {
+	cvss := models.Cvss3{VectorString: vector}
+	for _, s := range strings.Split(strings.TrimPrefix(vector, "CVSS:3.1/"), "/") {
+		m, v, ok := strings.Cut(s, ":")
+		if !ok {
+			continue
+		}
+		switch m {
+		case "AV":
+			switch v {
+			case "N":
+				cvss.AttackVector = "NETWORK"
+			case "A":
+				cvss.AttackVector = "ADJACENT_NETWORK"
+			case "L":
+				cvss.AttackVector = "LOCAL"
+			case "P":
+				cvss.AttackVector = "PHYSICAL"
+			default:
+				log.Warnf("%s is unknown Attack Vector", v)
+			}
+		case "AC":
+			switch v {
+			case "L":
+				cvss.AttackComplexity = "LOW"
+			case "H":
+				cvss.AttackComplexity = "HIGH"
+			default:
+				log.Warnf("%s is unknown Attack Complexity", v)
+			}
+		case "PR":
+			switch v {
+			case "N":
+				cvss.PrivilegesRequired = "NONE"
+			case "L":
+				cvss.PrivilegesRequired = "LOW"
+			case "H":
+				cvss.PrivilegesRequired = "HIGH"
+			default:
+				log.Warnf("%s is unknown Privileges Required", v)
+			}
+		case "UI":
+			switch v {
+			case "N":
+				cvss.UserInteraction = "NONE"
+			case "R":
+				cvss.UserInteraction = "REQUIRED"
+			default:
+				log.Warnf("%s is unknown User Interaction", v)
+			}
+		case "S":
+			switch v {
+			case "U":
+				cvss.Scope = "UNCHANGED"
+			case "C":
+				cvss.Scope = "CHANGED"
+			default:
+				log.Warnf("%s is unknown Scope", v)
+			}
+		case "C":
+			switch v {
+			case "N":
+				cvss.ConfidentialityImpact = "NONE"
+			case "L":
+				cvss.ConfidentialityImpact = "LOW"
+			case "H":
+				cvss.ConfidentialityImpact = "HIGH"
+			default:
+				log.Warnf("%s is unknown Confidentiality", v)
+			}
+		case "I":
+			switch v {
+			case "N":
+				cvss.IntegrityImpact = "NONE"
+			case "L":
+				cvss.IntegrityImpact = "LOW"
+			case "H":
+				cvss.IntegrityImpact = "HIGH"
+			default:
+				log.Warnf("%s is unknown Integrity", v)
+			}
+		case "A":
+			switch v {
+			case "N":
+				cvss.AvailabilityImpact = "NONE"
+			case "L":
+				cvss.AvailabilityImpact = "LOW"
+			case "H":
+				cvss.AvailabilityImpact = "HIGH"
+			default:
+				log.Warnf("%s is unknown Availability", v)
+			}
+		case "E", "RL", "RC", "CR", "IR", "AR", "MAV", "MAC", "MPR", "MUI", "MS", "MC", "MI", "MA":
+		default:
+			log.Warnf("%s is unknown metrics", m)
+		}
+	}
+
+	return cvss
+}

--- a/fetcher/fortinet/types.go
+++ b/fetcher/fortinet/types.go
@@ -1,0 +1,62 @@
+package fortinet
+
+import "time"
+
+type advisory struct {
+	ID              string          `json:"id"`
+	Title           string          `json:"title"`
+	Summary         string          `json:"summary"`
+	Description     string          `json:"description"`
+	Vulnerabilities []vulnerability `json:"vulnerabilities"`
+	References      []reference     `json:"references"`
+	Published       time.Time       `json:"published"`
+	Updated         time.Time       `json:"updated"`
+	AdvisoryURL     string          `json:"advisory_url"`
+}
+
+type vulnerability struct {
+	ID          string       `json:"id"`
+	CVE         string       `json:"cve"`
+	Definitions []definition `json:"definitions"`
+}
+
+type definition struct {
+	Configurations []configurations `json:"configurations"`
+	CVSSv2         *cvss            `json:"cvssv2"`
+	CVSSv3         *cvss            `json:"cvssv3"`
+	CWE            []string         `json:"cwe"`
+	Impact         string           `json:"impact"`
+	ExploitStatus  string           `json:"exploit_status"`
+}
+
+type configurations struct {
+	Nodes    []element       `json:"nodes"`
+	Children *configurations `json:"children"`
+}
+
+type element struct {
+	Description string     `json:"description"`
+	CPE         string     `json:"cpe"`
+	Affected    expression `json:"affected"`
+	FixedIn     []string   `json:"fixed_in"`
+}
+
+type expression struct {
+	Eqaul        *string `json:"eq"`
+	GreaterThan  *string `json:"gt"`
+	GreaterEqaul *string `json:"ge"`
+	LessThan     *string `json:"lt"`
+	LessEqual    *string `json:"le"`
+}
+
+type cvss struct {
+	BaseScore          *float64 `json:"base_score"`
+	TemporalScore      *float64 `json:"temporal_score"`
+	EnvironmentalScore *float64 `json:"environmental_score"`
+	Vector             string   `json:"vector"`
+}
+
+type reference struct {
+	Description string `json:"description"`
+	URL         string `json:"url"`
+}

--- a/models/models.go
+++ b/models/models.go
@@ -12,6 +12,8 @@ const (
 	NvdType = "NVD"
 	// JvnType :
 	JvnType = "JVN"
+	// FortinetType :
+	FortinetType = "Fortinet"
 
 	// NvdExactVersionMatch :
 	NvdExactVersionMatch = "NvdExactVersionMatch"
@@ -21,6 +23,12 @@ const (
 	NvdVendorProductMatch = "NvdVendorProductMatch"
 	// JvnVendorProductMatch :
 	JvnVendorProductMatch = "JvnVendorProductMatch"
+	// FortinetExactVersionMatch :
+	FortinetExactVersionMatch = "FortinetExactVersionMatch"
+	// FortinetRoughVersionMatch :
+	FortinetRoughVersionMatch = "FortinetRoughVersionMatch"
+	// FortinetVendorProductMatch :
+	FortinetVendorProductMatch = "FortinetVendorProductMatch"
 )
 
 // GetURLByYear returns url
@@ -60,9 +68,10 @@ func (f FetchMeta) OutDated() bool {
 
 // CveDetail :
 type CveDetail struct {
-	CveID string
-	Nvds  []Nvd
-	Jvns  []Jvn
+	CveID     string
+	Nvds      []Nvd
+	Jvns      []Jvn
+	Fortinets []Fortinet
 }
 
 // HasNvd returns true if NVD contents
@@ -75,10 +84,16 @@ func (c CveDetail) HasJvn() bool {
 	return len(c.Jvns) != 0
 }
 
+// HasFortinet returns true if Fortinet contents
+func (c CveDetail) HasFortinet() bool {
+	return len(c.Fortinets) != 0
+}
+
 // CpeDetail :
 type CpeDetail struct {
-	Nvds []NvdCpe
-	Jvns []JvnCpe
+	Nvds     []NvdCpe
+	Jvns     []JvnCpe
+	Fortinet []FortinetCpe
 }
 
 // Components common to Nvd and Jvn
@@ -294,4 +309,51 @@ type JvnCert struct {
 	ID    int64 `json:"-"`
 	JvnID uint  `json:"-" gorm:"index:idx_jvn_certs_jvn_id"`
 	Cert  `gorm:"embedded"`
+}
+
+// Fortinet is a model of Fortinet
+type Fortinet struct {
+	ID               int64  `json:"-"`
+	AdvisoryID       string `gorm:"type:varchar(255)"`
+	CveID            string `gorm:"index:idx_fortinets_cveid;type:varchar(255)"`
+	Title            string `gorm:"type:varchar(255)"`
+	Summary          string `gorm:"type:text"`
+	Descriptions     string `gorm:"type:text"`
+	Cvss3            FortinetCvss3
+	Cwes             []FortinetCwe
+	Cpes             []FortinetCpe
+	References       []FortinetReference
+	PublishedDate    time.Time
+	LastModifiedDate time.Time
+	AdvisoryURL      string `gorm:"type:text"`
+
+	DetectionMethod string `gorm:"-"`
+}
+
+// FortinetCvss3 has Fortinet CVSS3 info
+type FortinetCvss3 struct {
+	ID         int64 `json:"-"`
+	FortinetID uint  `json:"-" gorm:"index:idx_fortinet_cvss3_fortinet_id"`
+	Cvss3      `gorm:"embedded"`
+}
+
+// FortinetCwe has CweID
+type FortinetCwe struct {
+	ID         int64  `json:"-"`
+	FortinetID uint   `json:"-" index:"idx_fortinet_cwes_fortinet_id"`
+	CweID      string `gorm:"type:varchar(255)"`
+}
+
+// FortinetCpe is Child model of Fortinet.
+type FortinetCpe struct {
+	ID         int64 `json:"-"`
+	FortinetID uint  `json:"-" gorm:"index:idx_fortinet_cpes_fortinet_id"`
+	CpeBase    `gorm:"embedded"`
+}
+
+// FortinetReference holds reference information about the CVE.
+type FortinetReference struct {
+	ID         int64 `json:"-"`
+	FortinetID uint  `json:"-" gorm:"index:idx_fortinet_references_fortinet_id"`
+	Reference  `gorm:"embedded"`
 }

--- a/server/server.go
+++ b/server/server.go
@@ -100,12 +100,12 @@ func getCveIDsByCpeName(driver db.DB) echo.HandlerFunc {
 			log.Errorf("%s", err)
 			return err
 		}
-		nvds, jvns, err := driver.GetCveIDsByCpeURI(cpe.Name)
+		nvds, jvns, fortinets, err := driver.GetCveIDsByCpeURI(cpe.Name)
 		if err != nil {
 			log.Errorf("%s", err)
 			return err
 		}
-		cveIDs := map[string][]string{"NVD": nvds, "JVN": jvns}
+		cveIDs := map[string][]string{"NVD": nvds, "JVN": jvns, "Fortinet": fortinets}
 		return c.JSON(http.StatusOK, &cveIDs)
 	}
 }


### PR DESCRIPTION
# What did you implement:

new support for fortinet data feed

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

```console
// terminal 1
$ go-cve-dictionary fetch fortinet
INFO[09-20|22:38:18] Fetching... https://github.com/vulsio/vuls-data-raw-fortinet/archive/refs/heads/main.zip 
INFO[09-20|22:38:20] Inserting Fortinet into DB (sqlite3). 
INFO[09-20|22:38:20] Deleting Fortinet tables... 
INFO[09-20|22:38:20] Inserting fetched 822 CVEs... 
822 / 822 [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s
INFO[09-20|22:38:20] Refreshed 822 CVEs. 
INFO[09-20|22:38:20] Finished fetching Fortinet.

$ go-cve-dictionary server

// terminal 2
$ curl -s http://127.0.0.1:1323/cves/CVE-2023-33306 | jq "."
{
  "CveID": "CVE-2023-33306",
  "Nvds": [
    {
      "CveID": "CVE-2023-33306",
      "Descriptions": [
        {
          "Lang": "en",
          "Value": "A null pointer dereference in Fortinet FortiOS before 7.2.5,  before 7.0.11 and before 6.4.13, FortiProxy before 7.2.4 and before 7.0.10 allows attacker to denial of sslvpn service via specifically crafted request in bookmark parameter."
        }
      ],
      "Cvss2": {
        "VectorString": "",
        "AccessVector": "",
        "AccessComplexity": "",
        "Authentication": "",
        "ConfidentialityImpact": "",
        "IntegrityImpact": "",
        "AvailabilityImpact": "",
        "BaseScore": 0,
        "Severity": "",
        "ExploitabilityScore": 0,
        "ImpactScore": 0,
        "ObtainAllPrivilege": false,
        "ObtainUserPrivilege": false,
        "ObtainOtherPrivilege": false,
        "UserInteractionRequired": false
      },
      "Cvss3": {
        "VectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
        "AttackVector": "NETWORK",
        "AttackComplexity": "LOW",
        "PrivilegesRequired": "LOW",
        "UserInteraction": "NONE",
        "Scope": "UNCHANGED",
        "ConfidentialityImpact": "NONE",
        "IntegrityImpact": "NONE",
        "AvailabilityImpact": "HIGH",
        "BaseScore": 6.5,
        "BaseSeverity": "MEDIUM",
        "ExploitabilityScore": 2.8,
        "ImpactScore": 3.6
      },
      "Cwes": [
        {
          "CweID": "CWE-476"
        }
      ],
      "Cpes": [
        {
          "URI": "cpe:/o:fortinet:fortios",
          "FormattedString": "cpe:2.3:o:fortinet:fortios:*:*:*:*:*:*:*:*",
          "WellFormedName": "wfn:[part=\"o\", vendor=\"fortinet\", product=\"fortios\", version=ANY, update=ANY, edition=ANY, language=ANY, sw_edition=ANY, target_sw=ANY, target_hw=ANY, other=ANY]",
          "Part": "o",
          "Vendor": "fortinet",
          "Product": "fortios",
          "Version": "ANY",
          "Update": "ANY",
          "Edition": "ANY",
          "Language": "ANY",
          "SoftwareEdition": "ANY",
          "TargetSW": "ANY",
          "TargetHW": "ANY",
          "Other": "ANY",
          "VersionStartExcluding": "",
          "VersionStartIncluding": "7.0.0",
          "VersionEndExcluding": "7.0.11",
          "VersionEndIncluding": "",
          "EnvCpes": []
        },
        {
          "URI": "cpe:/a:fortinet:fortiproxy",
          "FormattedString": "cpe:2.3:a:fortinet:fortiproxy:*:*:*:*:*:*:*:*",
          "WellFormedName": "wfn:[part=\"a\", vendor=\"fortinet\", product=\"fortiproxy\", version=ANY, update=ANY, edition=ANY, language=ANY, sw_edition=ANY, target_sw=ANY, target_hw=ANY, other=ANY]",
          "Part": "a",
          "Vendor": "fortinet",
          "Product": "fortiproxy",
          "Version": "ANY",
          "Update": "ANY",
          "Edition": "ANY",
          "Language": "ANY",
          "SoftwareEdition": "ANY",
          "TargetSW": "ANY",
          "TargetHW": "ANY",
          "Other": "ANY",
          "VersionStartExcluding": "",
          "VersionStartIncluding": "7.2.0",
          "VersionEndExcluding": "7.2.4",
          "VersionEndIncluding": "",
          "EnvCpes": []
        },
        {
          "URI": "cpe:/a:fortinet:fortiproxy",
          "FormattedString": "cpe:2.3:a:fortinet:fortiproxy:*:*:*:*:*:*:*:*",
          "WellFormedName": "wfn:[part=\"a\", vendor=\"fortinet\", product=\"fortiproxy\", version=ANY, update=ANY, edition=ANY, language=ANY, sw_edition=ANY, target_sw=ANY, target_hw=ANY, other=ANY]",
          "Part": "a",
          "Vendor": "fortinet",
          "Product": "fortiproxy",
          "Version": "ANY",
          "Update": "ANY",
          "Edition": "ANY",
          "Language": "ANY",
          "SoftwareEdition": "ANY",
          "TargetSW": "ANY",
          "TargetHW": "ANY",
          "Other": "ANY",
          "VersionStartExcluding": "",
          "VersionStartIncluding": "7.0.0",
          "VersionEndExcluding": "7.0.10",
          "VersionEndIncluding": "",
          "EnvCpes": []
        },
        {
          "URI": "cpe:/o:fortinet:fortios",
          "FormattedString": "cpe:2.3:o:fortinet:fortios:*:*:*:*:*:*:*:*",
          "WellFormedName": "wfn:[part=\"o\", vendor=\"fortinet\", product=\"fortios\", version=ANY, update=ANY, edition=ANY, language=ANY, sw_edition=ANY, target_sw=ANY, target_hw=ANY, other=ANY]",
          "Part": "o",
          "Vendor": "fortinet",
          "Product": "fortios",
          "Version": "ANY",
          "Update": "ANY",
          "Edition": "ANY",
          "Language": "ANY",
          "SoftwareEdition": "ANY",
          "TargetSW": "ANY",
          "TargetHW": "ANY",
          "Other": "ANY",
          "VersionStartExcluding": "",
          "VersionStartIncluding": "7.2.0",
          "VersionEndExcluding": "7.2.5",
          "VersionEndIncluding": "",
          "EnvCpes": []
        },
        {
          "URI": "cpe:/o:fortinet:fortios",
          "FormattedString": "cpe:2.3:o:fortinet:fortios:*:*:*:*:*:*:*:*",
          "WellFormedName": "wfn:[part=\"o\", vendor=\"fortinet\", product=\"fortios\", version=ANY, update=ANY, edition=ANY, language=ANY, sw_edition=ANY, target_sw=ANY, target_hw=ANY, other=ANY]",
          "Part": "o",
          "Vendor": "fortinet",
          "Product": "fortios",
          "Version": "ANY",
          "Update": "ANY",
          "Edition": "ANY",
          "Language": "ANY",
          "SoftwareEdition": "ANY",
          "TargetSW": "ANY",
          "TargetHW": "ANY",
          "Other": "ANY",
          "VersionStartExcluding": "",
          "VersionStartIncluding": "6.4.0",
          "VersionEndExcluding": "6.4.13",
          "VersionEndIncluding": "",
          "EnvCpes": []
        }
      ],
      "References": [
        {
          "Link": "https://fortiguard.com/psirt/FG-IR-23-015",
          "Source": "MISC",
          "Tags": "Vendor Advisory",
          "Name": "https://fortiguard.com/psirt/FG-IR-23-015"
        }
      ],
      "Certs": [],
      "PublishedDate": "2023-06-16T10:15:00Z",
      "LastModifiedDate": "2023-06-23T21:27:00Z",
      "DetectionMethod": ""
    }
  ],
  "Jvns": [],
  "Fortinets": [
    {
      "AdvisoryID": "FG-IR-23-015",
      "CveID": "CVE-2023-33306",
      "Title": "FortiOS & FortiProxy: authenticated user null pointer dereference in SSL-VPN",
      "Summary": "A NULL pointer dereference vulnerability [CWE-476] in SSL-VPN may allow an authenticated remote attacker to trigger a crash of the SSL-VPN service via crafted requests.",
      "Descriptions": "",
      "Cvss3": {
        "VectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H/E:F/RL:X/RC:C",
        "AttackVector": "NETWORK",
        "AttackComplexity": "LOW",
        "PrivilegesRequired": "LOW",
        "UserInteraction": "NONE",
        "Scope": "UNCHANGED",
        "ConfidentialityImpact": "NONE",
        "IntegrityImpact": "NONE",
        "AvailabilityImpact": "HIGH",
        "BaseScore": 6.4,
        "BaseSeverity": "",
        "ExploitabilityScore": 0,
        "ImpactScore": 0
      },
      "Cwes": [
        {
          "CweID": "CWE-476"
        }
      ],
      "Cpes": [
        {
          "URI": "cpe:/o:fortinet:fortiproxy",
          "FormattedString": "cpe:2.3:o:fortinet:fortiproxy:*:*:*:*:*:*:*:*",
          "WellFormedName": "wfn:[part=\"o\", vendor=\"fortinet\", product=\"fortiproxy\", version=ANY, update=ANY, edition=ANY, language=ANY, sw_edition=ANY, target_sw=ANY, target_hw=ANY, other=ANY]",
          "Part": "o",
          "Vendor": "fortinet",
          "Product": "fortiproxy",
          "Version": "ANY",
          "Update": "ANY",
          "Edition": "ANY",
          "Language": "ANY",
          "SoftwareEdition": "ANY",
          "TargetSW": "ANY",
          "TargetHW": "ANY",
          "Other": "ANY",
          "VersionStartExcluding": "",
          "VersionStartIncluding": "7.0.0",
          "VersionEndExcluding": "",
          "VersionEndIncluding": "7.0.9"
        },
        {
          "URI": "cpe:/o:fortinet:fortiproxy",
          "FormattedString": "cpe:2.3:o:fortinet:fortiproxy:*:*:*:*:*:*:*:*",
          "WellFormedName": "wfn:[part=\"o\", vendor=\"fortinet\", product=\"fortiproxy\", version=ANY, update=ANY, edition=ANY, language=ANY, sw_edition=ANY, target_sw=ANY, target_hw=ANY, other=ANY]",
          "Part": "o",
          "Vendor": "fortinet",
          "Product": "fortiproxy",
          "Version": "ANY",
          "Update": "ANY",
          "Edition": "ANY",
          "Language": "ANY",
          "SoftwareEdition": "ANY",
          "TargetSW": "ANY",
          "TargetHW": "ANY",
          "Other": "ANY",
          "VersionStartExcluding": "",
          "VersionStartIncluding": "7.2.0",
          "VersionEndExcluding": "",
          "VersionEndIncluding": "7.2.3"
        }
      ],
      "References": null,
      "PublishedDate": "2023-06-16T00:00:00Z",
      "LastModifiedDate": "2023-06-16T00:00:00Z",
      "AdvisoryURL": "https://www.fortiguard.com/psirt/FG-IR-23-015",
      "DetectionMethod": ""
    }
  ]
}

$ curl -s -H "Accept: application/json" -H "Content-type: application/json" -X POST -d '{"name": "cpe:/o:fortinet:fortios:4.3.0"}' http://localhost:1323/cpes/ids | jq "."
{
  "Fortinet": [
    "CVE-2018-13367",
    "CVE-2015-0204",
    "CVE-2016-8492",
    "CVE-2016-5766",
    "CVE-2015-0286",
    "CVE-2016-8497",
    "CVE-2016-10168",
    "CVE-2016-6132",
    "CVE-2016-6207",
    "CVE-2009-3555",
    "CVE-2016-1550",
    "CVE-2017-3133",
    "CVE-2016-9933",
    "CVE-2014-0351",
    "CVE-2018-9185",
    "CVE-2016-6128",
    "CVE-2013-7182",
    "CVE-2014-0352",
    "CVE-2016-5767",
    "CVE-2015-8874",
    "CVE-2015-1452",
    "CVE-2018-13365",
    "CVE-2016-5696",
    "CVE-2012-0941",
    "CVE-2016-9317",
    "CVE-2016-10166",
    "CVE-2018-13380",
    "CVE-2018-13374",
    "CVE-2013-1414",
    "CVE-2018-13371",
    "CVE-2019-5591",
    "CVE-2016-6214",
    "CVE-2017-13081",
    "CVE-2018-13366",
    "CVE-2017-17544",
    "CVE-2015-5738",
    "CVE-2017-7738",
    "CVE-2016-6912",
    "CVE-2015-1451",
    "CVE-2017-3132",
    "CVE-2018-13381",
    "CVE-2016-8496",
    "CVE-2016-10167",
    "CVE-2018-9195",
    "CVE-2017-14186"
  ],
  "JVN": [
    "CVE-2016-8497",
    "CVE-2015-5738",
    "CVE-2017-7738"
  ],
  "NVD": [
    "CVE-2018-13367",
    "CVE-2016-8492",
    "CVE-2019-15703",
    "CVE-2018-13384",
    "CVE-2019-5587",
    "CVE-2020-12812",
    "CVE-2015-3626",
    "CVE-2019-5593",
    "CVE-2019-17655",
    "CVE-2017-3133",
    "CVE-2019-6693",
    "CVE-2022-23438",
    "CVE-2014-0351",
    "CVE-2018-9185",
    "CVE-2021-44168",
    "CVE-2019-15705",
    "CVE-2018-13383",
    "CVE-2018-13365",
    "CVE-2018-13376",
    "CVE-2012-0941",
    "CVE-2014-2216",
    "CVE-2019-17656",
    "CVE-2015-5965",
    "CVE-2017-14190",
    "CVE-2018-13380",
    "CVE-2021-24018",
    "CVE-2016-1909",
    "CVE-2018-13374",
    "CVE-2013-1414",
    "CVE-2020-12818",
    "CVE-2018-13371",
    "CVE-2019-5591",
    "CVE-2016-6909",
    "CVE-2017-14187",
    "CVE-2018-13366",
    "CVE-2020-6648",
    "CVE-2017-17544",
    "CVE-2013-4604",
    "CVE-2017-3132",
    "CVE-2018-13381",
    "CVE-2020-15938",
    "CVE-2018-9195",
    "CVE-2017-14186"
  ]
}

$ curl -s -H "Accept: application/json" -H "Content-type: application/json" -X POST -d '{"name": "cpe:/o:fortinet:fortios:4.3.0"}' http://localhost:1323/cpes | jq "."
[
  {
    "CveID": "CVE-2009-3555",
    "Nvds": [],
    "Jvns": [],
    "Fortinets": [
      {
        "AdvisoryID": "FG-IR-17-137",
        "CveID": "CVE-2009-3555",
        "Title": "FortiOS SSL Deep-Inspection possible Insecure Renegotiation",
        "Summary": "FortiOS SSL Deep-Inspection may enable insecure renegotiation between TLS clients and servers that support secure renegotiation, opening the door to potential Man-in-the-Middle attacks (CVE-2009-3555) against the TLS connection, where an attacker could inject arbitrary data in the connection (without however being able to decipher it).The fix enables secure renegotiation on the SSL Deep-Inspection when both the client and server support it.",
        "Descriptions": "",
        "Cvss3": {
          "VectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:X/RL:X/RC:X",
          "AttackVector": "NETWORK",
          "AttackComplexity": "LOW",
          "PrivilegesRequired": "NONE",
          "UserInteraction": "NONE",
          "Scope": "UNCHANGED",
          "ConfidentialityImpact": "LOW",
          "IntegrityImpact": "LOW",
          "AvailabilityImpact": "LOW",
          "BaseScore": 7.3,
          "BaseSeverity": "",
          "ExploitabilityScore": 0,
          "ImpactScore": 0
        },
        "Cwes": [],
        "Cpes": [
          {
            "URI": "cpe:/o:fortinet:fortios",
            "FormattedString": "cpe:2.3:o:fortinet:fortios:*:*:*:*:*:*:*:*",
            "WellFormedName": "wfn:[part=\"o\", vendor=\"fortinet\", product=\"fortios\", version=ANY, update=ANY, edition=ANY, language=ANY, sw_edition=ANY, target_sw=ANY, target_hw=ANY, other=ANY]",
            "Part": "o",
            "Vendor": "fortinet",
            "Product": "fortios",
            "Version": "ANY",
            "Update": "ANY",
            "Edition": "ANY",
            "Language": "ANY",
            "SoftwareEdition": "ANY",
            "TargetSW": "ANY",
            "TargetHW": "ANY",
            "Other": "ANY",
            "VersionStartExcluding": "",
            "VersionStartIncluding": "",
            "VersionEndExcluding": "",
            "VersionEndIncluding": "5.0.14"
          },
          {
            "URI": "cpe:/o:fortinet:fortios",
            "FormattedString": "cpe:2.3:o:fortinet:fortios:*:*:*:*:*:*:*:*",
            "WellFormedName": "wfn:[part=\"o\", vendor=\"fortinet\", product=\"fortios\", version=ANY, update=ANY, edition=ANY, language=ANY, sw_edition=ANY, target_sw=ANY, target_hw=ANY, other=ANY]",
            "Part": "o",
            "Vendor": "fortinet",
            "Product": "fortios",
            "Version": "ANY",
            "Update": "ANY",
            "Edition": "ANY",
            "Language": "ANY",
            "SoftwareEdition": "ANY",
            "TargetSW": "ANY",
            "TargetHW": "ANY",
            "Other": "ANY",
            "VersionStartExcluding": "",
            "VersionStartIncluding": "5.2.0",
            "VersionEndExcluding": "",
            "VersionEndIncluding": "5.2.12"
          },
          {
            "URI": "cpe:/o:fortinet:fortios",
            "FormattedString": "cpe:2.3:o:fortinet:fortios:*:*:*:*:*:*:*:*",
            "WellFormedName": "wfn:[part=\"o\", vendor=\"fortinet\", product=\"fortios\", version=ANY, update=ANY, edition=ANY, language=ANY, sw_edition=ANY, target_sw=ANY, target_hw=ANY, other=ANY]",
            "Part": "o",
            "Vendor": "fortinet",
            "Product": "fortios",
            "Version": "ANY",
            "Update": "ANY",
            "Edition": "ANY",
            "Language": "ANY",
            "SoftwareEdition": "ANY",
            "TargetSW": "ANY",
            "TargetHW": "ANY",
            "Other": "ANY",
            "VersionStartExcluding": "",
            "VersionStartIncluding": "5.4.0",
            "VersionEndExcluding": "",
            "VersionEndIncluding": "5.4.5"
          },
          {
            "URI": "cpe:/o:fortinet:fortios:5.6.0",
            "FormattedString": "cpe:2.3:o:fortinet:fortios:5.6.0:*:*:*:*:*:*:*",
            "WellFormedName": "wfn:[part=\"o\", vendor=\"fortinet\", product=\"fortios\", version=\"5\\.6\\.0\", update=ANY, edition=ANY, language=ANY, sw_edition=ANY, target_sw=ANY, target_hw=ANY, other=ANY]",
            "Part": "o",
            "Vendor": "fortinet",
            "Product": "fortios",
            "Version": "5\\.6\\.0",
            "Update": "ANY",
            "Edition": "ANY",
            "Language": "ANY",
            "SoftwareEdition": "ANY",
            "TargetSW": "ANY",
            "TargetHW": "ANY",
            "Other": "ANY",
            "VersionStartExcluding": "",
            "VersionStartIncluding": "",
            "VersionEndExcluding": "",
            "VersionEndIncluding": ""
          }
        ],
        "References": [],
        "PublishedDate": "2017-11-03T00:00:00Z",
        "LastModifiedDate": "2017-11-03T00:00:00Z",
        "AdvisoryURL": "https://www.fortiguard.com/psirt/FG-IR-17-137",
        "DetectionMethod": "FortinetExactVersionMatch"
      }
    ]
  },
  {
    "CveID": "CVE-2012-0941",
    "Nvds": [
      {
        "CveID": "CVE-2012-0941",
        "Descriptions": [
          {
            "Lang": "en",
            "Value": "Multiple cross-site scripting (XSS) vulnerabilities in Fortinet FortiGate UTM WAF appliances with FortiOS 4.3.x before 4.3.6 allow remote attackers to inject arbitrary web script or HTML via vectors involving the (1) Endpoint Monitor, (2) Dialup List, or (3) Log&Report Display modules, or the fields_sorted_opt parameter to (4) user/auth/list or (5) endpointcompliance/app_detect/predefined_sig_list."
          }
        ],
        "Cvss2": {
          "VectorString": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
          "AccessVector": "NETWORK",
          "AccessComplexity": "MEDIUM",
          "Authentication": "NONE",
          "ConfidentialityImpact": "NONE",
          "IntegrityImpact": "PARTIAL",
          "AvailabilityImpact": "NONE",
          "BaseScore": 4.3,
          "Severity": "MEDIUM",
          "ExploitabilityScore": 8.6,
          "ImpactScore": 2.9,
          "ObtainAllPrivilege": false,
          "ObtainUserPrivilege": false,
          "ObtainOtherPrivilege": false,
          "UserInteractionRequired": true
        },
        "Cvss3": {
          "VectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
          "AttackVector": "NETWORK",
          "AttackComplexity": "LOW",
          "PrivilegesRequired": "NONE",
          "UserInteraction": "REQUIRED",
          "Scope": "CHANGED",
          "ConfidentialityImpact": "LOW",
          "IntegrityImpact": "LOW",
          "AvailabilityImpact": "NONE",
          "BaseScore": 6.1,
          "BaseSeverity": "MEDIUM",
          "ExploitabilityScore": 2.8,
          "ImpactScore": 2.7
        },
        "Cwes": [
          {
            "CweID": "CWE-79"
          }
        ],
        "Cpes": [
          {
            "URI": "cpe:/o:fortinet:fortios",
            "FormattedString": "cpe:2.3:o:fortinet:fortios:*:*:*:*:*:*:*:*",
            "WellFormedName": "wfn:[part=\"o\", vendor=\"fortinet\", product=\"fortios\", version=ANY, update=ANY, edition=ANY, language=ANY, sw_edition=ANY, target_sw=ANY, target_hw=ANY, other=ANY]",
            "Part": "o",
            "Vendor": "fortinet",
            "Product": "fortios",
            "Version": "ANY",
            "Update": "ANY",
            "Edition": "ANY",
            "Language": "ANY",
            "SoftwareEdition": "ANY",
            "TargetSW": "ANY",
            "TargetHW": "ANY",
            "Other": "ANY",
            "VersionStartExcluding": "",
            "VersionStartIncluding": "4.3.0",
            "VersionEndExcluding": "4.3.6",
            "VersionEndIncluding": "",
            "EnvCpes": []
          }
        ],
        "References": [
          {
            "Link": "https://www.vulnerability-lab.com/get_content.php?id=144",
            "Source": "MISC",
            "Tags": "Exploit,Third Party Advisory",
            "Name": "https://www.vulnerability-lab.com/get_content.php?id=144"
          },
          {
            "Link": "https://securitytracker.com/id/1026594",
            "Source": "SECTRACK",
            "Tags": "Third Party Advisory,VDB Entry",
            "Name": "1026594"
          },
          {
            "Link": "https://fortiguard.com/psirt/FG-IR-012-001",
            "Source": "CONFIRM",
            "Tags": "Vendor Advisory",
            "Name": "https://fortiguard.com/psirt/FG-IR-012-001"
          },
          {
            "Link": "https://exchange.xforce.ibmcloud.com/vulnerabilities/72761",
            "Source": "XF",
            "Tags": "VDB Entry",
            "Name": "fortigateutm-fieldssortedopt-xss(72761)"
          },
          {
            "Link": "http://www.securityfocus.com/bid/51708",
            "Source": "BID",
            "Tags": "Third Party Advisory,VDB Entry",
            "Name": "51708"
          },
          {
            "Link": "http://packetstormsecurity.org/files/109168/VL-144.txt",
            "Source": "MISC",
            "Tags": "Exploit,Third Party Advisory,VDB Entry",
            "Name": "http://packetstormsecurity.org/files/109168/VL-144.txt"
          }
        ],
        "Certs": [],
        "PublishedDate": "2018-02-08T23:29:00Z",
        "LastModifiedDate": "2018-02-27T19:44:00Z",
        "DetectionMethod": "NvdExactVersionMatch"
      }
    ],
    "Jvns": [],
    "Fortinets": [
      {
        "AdvisoryID": "FG-IR-012-001",
        "CveID": "CVE-2012-0941",
        "Title": "Potential Information Disclosure Vulnerability in FortiGate",
        "Summary": "On January 27, 2012, vulnerability-lab.com publicly released news of discovered vulnerabilities discovered in FortiGate UTM WAF Appliances platforms.",
        "Descriptions": "On January 27, 2012, vulnerability-lab.com publicly released news of discovered vulnerabilities discovered in FortiGate UTM WAF Appliances platforms.",
        "Cvss3": {
          "VectorString": "",
          "AttackVector": "",
          "AttackComplexity": "",
          "PrivilegesRequired": "",
          "UserInteraction": "",
          "Scope": "",
          "ConfidentialityImpact": "",
          "IntegrityImpact": "",
          "AvailabilityImpact": "",
          "BaseScore": 0,
          "BaseSeverity": "",
          "ExploitabilityScore": 0,
          "ImpactScore": 0
        },
        "Cwes": [],
        "Cpes": [
          {
            "URI": "cpe:/o:fortinet:fortios",
            "FormattedString": "cpe:2.3:o:fortinet:fortios:*:*:*:*:*:*:*:*",
            "WellFormedName": "wfn:[part=\"o\", vendor=\"fortinet\", product=\"fortios\", version=ANY, update=ANY, edition=ANY, language=ANY, sw_edition=ANY, target_sw=ANY, target_hw=ANY, other=ANY]",
            "Part": "o",
            "Vendor": "fortinet",
            "Product": "fortios",
            "Version": "ANY",
            "Update": "ANY",
            "Edition": "ANY",
            "Language": "ANY",
            "SoftwareEdition": "ANY",
            "TargetSW": "ANY",
            "TargetHW": "ANY",
            "Other": "ANY",
            "VersionStartExcluding": "",
            "VersionStartIncluding": "4.3.0",
            "VersionEndExcluding": "",
            "VersionEndIncluding": "4.3.5"
          }
        ],
        "References": [
          {
            "Link": "<a href=\"http://vulnerability-lab.com/get_content.php?id=144\">Vulnerability Research Laboratory (VL-ID 144)</a>",
            "Source": "",
            "Tags": "",
            "Name": "<a href=\"http://vulnerability-lab.com/get_content.php?id=144\">Vulnerability Research Laboratory (VL-ID 144)</a>"
          },
          {
            "Link": "<a href=\"http://secunia.com/advisories/47693\">Secunia Advisory SA47693</a>",
            "Source": "",
            "Tags": "",
            "Name": "<a href=\"http://secunia.com/advisories/47693\">Secunia Advisory SA47693</a>"
          },
          {
            "Link": "<a href=\"http://www.securityfocus.com/bid/51708\">Security Focus (51708)</a>",
            "Source": "",
            "Tags": "",
            "Name": "<a href=\"http://www.securityfocus.com/bid/51708\">Security Focus (51708)</a>"
          },
          {
            "Link": "<a href=\"http://xforce.iss.net/xforce/xfdb/72761\">IBM ISS (72761)</a>",
            "Source": "",
            "Tags": "",
            "Name": "<a href=\"http://xforce.iss.net/xforce/xfdb/72761\">IBM ISS (72761)</a>"
          }
        ],
        "PublishedDate": "2012-02-01T00:00:00Z",
        "LastModifiedDate": "2012-03-26T00:00:00Z",
        "AdvisoryURL": "https://www.fortiguard.com/psirt/FG-IR-012-001",
        "DetectionMethod": "FortinetExactVersionMatch"
      }
    ]
  },
  ...
]

```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
