### PR TITLE
chore(command): --without-jvncert flag limited to jvn command

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,13 +247,12 @@ Available Commands:
   nvd         Fetch Vulnerability dictionary from NVD
 
 Flags:
-      --batch-size int    The number of batch size to insert. (default 5)
-  -h, --help              help for fetch
-      --without-jvncert   not request to jvn cert (only jvn).
+      --batch-size int   The number of batch size to insert. (default 5)
+  -h, --help             help for fetch
 
 Global Flags:
       --config string       config file (default is $HOME/.go-cve-dictionary.yaml)
-      --dbpath string       /path/to/sqlite3 or SQL connection string (default "/go-cve-dictionary/cve.sqlite3")
+      --dbpath string       /path/to/sqlite3 or SQL connection string (default "$PWD/cve.sqlite3")
       --dbtype string       Database type to store data in (sqlite3, mysql, postgres or redis supported) (default "sqlite3")
       --debug               debug mode (default: false)
       --debug-sql           SQL debug mode

--- a/commands/fetch.go
+++ b/commands/fetch.go
@@ -16,7 +16,4 @@ func init() {
 
 	fetchCmd.PersistentFlags().Int("batch-size", 5, "The number of batch size to insert.")
 	_ = viper.BindPFlag("batch-size", fetchCmd.PersistentFlags().Lookup("batch-size"))
-
-	fetchCmd.PersistentFlags().Bool("without-jvncert", false, "not request to jvn cert (only jvn).")
-	_ = viper.BindPFlag("without-jvncert", fetchCmd.PersistentFlags().Lookup("without-jvncert"))
 }

--- a/commands/fetchjvn.go
+++ b/commands/fetchjvn.go
@@ -5,10 +5,11 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"golang.org/x/xerrors"
+
 	db "github.com/vulsio/go-cve-dictionary/db"
 	log "github.com/vulsio/go-cve-dictionary/log"
 	"github.com/vulsio/go-cve-dictionary/models"
-	"golang.org/x/xerrors"
 )
 
 var fetchJvnCmd = &cobra.Command{
@@ -20,6 +21,9 @@ var fetchJvnCmd = &cobra.Command{
 
 func init() {
 	fetchCmd.AddCommand(fetchJvnCmd)
+
+	fetchJvnCmd.PersistentFlags().Bool("without-jvncert", false, "not request to jvn cert.")
+	_ = viper.BindPFlag("without-jvncert", fetchJvnCmd.PersistentFlags().Lookup("without-jvncert"))
 }
 
 func fetchJvn(_ *cobra.Command, args []string) (err error) {


### PR DESCRIPTION
# What did you implement:

`--without-jvncert` added by #335 is a flag that can only be used with JVN command. Therefore, it should be a flag limited to JVN command.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## before

```console
$ go-cve-dictionary fetch -h
Fetch Vulnerability dictionary

Usage:
  go-cve-dictionary fetch [command]

Available Commands:
  fortinet    Fetch Vulnerability dictionary from Fortinet Advisories
  jvn         Fetch Vulnerability dictionary from JVN
  nvd         Fetch Vulnerability dictionary from NVD

Flags:
      --batch-size int    The number of batch size to insert. (default 5)
  -h, --help              help for fetch
      --without-jvncert   not request to jvn cert (only jvn).

Global Flags:
...
```

## after
```console
$ go-cve-dictionary fetch -h
Fetch Vulnerability dictionary

Usage:
  go-cve-dictionary fetch [command]

Available Commands:
  fortinet    Fetch Vulnerability dictionary from Fortinet Advisories
  jvn         Fetch Vulnerability dictionary from JVN
  nvd         Fetch Vulnerability dictionary from NVD

Flags:
      --batch-size int   The number of batch size to insert. (default 5)
  -h, --help             help for fetch

Global Flags:
...

$ go-cve-dictionary fetch jvn -h
Fetch Vulnerability dictionary from JVN

Usage:
  go-cve-dictionary fetch jvn [flags]

Flags:
  -h, --help              help for jvn
      --without-jvncert   not request to jvn cert.

Global Flags:
      --batch-size int      The number of batch size to insert. (default 5)
...

$ go-cve-dictionary fetch jvn --without-jvncert
...
INFO[09-25|15:48:06] Inserting fetched CVEs(2023)... 
2998 / 2998 [-------------------------------------------------] 100.00% 4054 p/s
INFO[09-25|15:48:07] Refreshed 2998 CVEs. 
INFO[09-25|15:48:08] Finished fetching JVN. 
```


# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

