### PR TITLE
feat(db,server): add GetCveIDs

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -29,6 +29,7 @@ type DB interface {
 
 	Get(string) (*models.CveDetail, error)
 	GetMulti([]string) (map[string]models.CveDetail, error)
+	GetCveIDs() ([]string, error)
 	GetCveIDsByCpeURI(string) ([]string, []string, []string, error)
 	GetByCpeURI(string) ([]models.CveDetail, error)
 	InsertJvn([]string) error

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -14,6 +14,7 @@ import (
 	"github.com/knqyf263/go-cpe/common"
 	"github.com/knqyf263/go-cpe/naming"
 	"github.com/spf13/viper"
+	"golang.org/x/exp/maps"
 	"golang.org/x/xerrors"
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/postgres"
@@ -306,6 +307,37 @@ func (r *RDBDriver) Get(cveID string) (*models.CveDetail, error) {
 	}
 
 	return &detail, nil
+}
+
+// GetCveIDs select all cve ids
+func (r *RDBDriver) GetCveIDs() ([]string, error) {
+	cveIDs := map[string]struct{}{}
+
+	var nvds []string
+	if err := r.conn.Model(&models.Nvd{}).Pluck("cve_id", &nvds).Error; err != nil {
+		return nil, err
+	}
+	for _, cveID := range nvds {
+		cveIDs[cveID] = struct{}{}
+	}
+
+	var jvns []string
+	if err := r.conn.Model(&models.Jvn{}).Distinct().Pluck("cve_id", &jvns).Error; err != nil {
+		return nil, err
+	}
+	for _, cveID := range jvns {
+		cveIDs[cveID] = struct{}{}
+	}
+
+	var fortinets []string
+	if err := r.conn.Model(&models.Fortinet{}).Distinct().Pluck("cve_id", &fortinets).Error; err != nil {
+		return nil, err
+	}
+	for _, cveID := range fortinets {
+		cveIDs[cveID] = struct{}{}
+	}
+
+	return maps.Keys(cveIDs), nil
 }
 
 func (r *RDBDriver) getCveIDsByPartVendorProduct(uri string) ([]string, error) {

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -189,9 +189,7 @@ func (r *RDBDriver) MigrateDB() error {
 				}
 			}
 		case dialectMysql, dialectPostgreSQL:
-			if err != nil {
-				return xerrors.Errorf("Failed to migrate. err: %w", err)
-			}
+			return xerrors.Errorf("Failed to migrate. err: %w", err)
 		default:
 			return xerrors.Errorf("Not Supported DB dialects. r.name: %s", r.name)
 		}

--- a/db/redis.go
+++ b/db/redis.go
@@ -256,6 +256,35 @@ func (r *RedisDriver) GetMulti(cveIDs []string) (map[string]models.CveDetail, er
 	return cveDetails, nil
 }
 
+// GetCveIDs select all cve ids
+func (r *RedisDriver) GetCveIDs() ([]string, error) {
+	ctx := context.Background()
+
+	dbsize, err := r.conn.DBSize(ctx).Result()
+	if err != nil {
+		return nil, xerrors.Errorf("Failed to DBSize. err: %w", err)
+	}
+
+	cveIDs := []string{}
+	var cursor uint64
+	for {
+		var keys []string
+		var err error
+		keys, cursor, err = r.conn.Scan(ctx, cursor, fmt.Sprintf(cveKeyFormat, "*"), dbsize/5).Result()
+		if err != nil {
+			return nil, xerrors.Errorf("Failed to Scan. err: %w", err)
+		}
+
+		cveIDs = append(cveIDs, keys...)
+
+		if cursor == 0 {
+			break
+		}
+	}
+
+	return cveIDs, nil
+}
+
 // GetCveIDsByCpeURI Select Cve Ids by by pseudo-CPE
 func (r *RedisDriver) GetCveIDsByCpeURI(uri string) ([]string, []string, []string, error) {
 	specified, err := naming.UnbindURI(uri)

--- a/db/redis.go
+++ b/db/redis.go
@@ -533,7 +533,7 @@ func (r *RedisDriver) InsertNvd(years []string) error {
 	}
 	var err error
 
-	log.Infof("Fetching CVE information from NVD(recent, modified).")
+	log.Infof("Fetching CVE information from NVD.")
 	cacheDir, err := nvd.Fetch()
 	if err != nil {
 		return xerrors.Errorf("Failed to Fetch. err: %w", err)

--- a/server/server.go
+++ b/server/server.go
@@ -38,6 +38,8 @@ func Start(logToFile bool, logDir string, driver db.DB) error {
 	// Routes
 	e.GET("/health", health())
 	e.GET("/cves/:id", getCve(driver))
+	e.POST("/cves", getCveMulti(driver))
+	e.GET("/cves/ids", getCveIDs(driver))
 	e.POST("/cpes", getCveByCpeName(driver))
 	e.POST("/cpes/ids", getCveIDsByCpeName(driver))
 
@@ -67,6 +69,23 @@ func getCve(driver db.DB) echo.HandlerFunc {
 	}
 }
 
+func getCveMulti(driver db.DB) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		var cveIDs []string
+		if err := c.Bind(&cveIDs); err != nil {
+			log.Errorf("%s", err)
+			return err
+		}
+
+		cveDetails, err := driver.GetMulti(cveIDs)
+		if err != nil {
+			log.Errorf("%s", err)
+			return err
+		}
+		return c.JSON(http.StatusOK, &cveDetails)
+	}
+}
+
 type cpeName struct {
 	Name string `form:"name"`
 }
@@ -89,6 +108,17 @@ func getCveByCpeName(driver db.DB) echo.HandlerFunc {
 			return cveDetails[i].CveID < cveDetails[j].CveID
 		})
 		return c.JSON(http.StatusOK, &cveDetails)
+	}
+}
+
+func getCveIDs(driver db.DB) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		cveIDs, err := driver.GetCveIDs()
+		if err != nil {
+			log.Errorf("%s", err)
+			return err
+		}
+		return c.JSON(http.StatusOK, &cveIDs)
 	}
 }
 


### PR DESCRIPTION
# What did you implement:
This PR allows you to obtain the CVE ID list registered in the DB.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
```console
$ curl http://127.0.0.1:1323/cves/ids
["CVE-2023-21043","CVE-2023-37256", ... ,"CVE-2023-46765"]

$ curl -X POST  -H "Content-Type: application/json" --data '["CVE-2023-0706", "CVE-2023-2569"]' http://127.0.0.1:1323/cves | jq
{
  "CVE-2023-0706": {
    "CveID": "CVE-2023-0706",
    "Nvds": [
      {
        "CveID": "CVE-2023-0706",
        "Descriptions": [
          {
            "Lang": "en",
            "Value": "A vulnerability, which was classified as critical, has been found in SourceCodester Medical Certificate Generator App 1.0. Affected by this issue is some unknown functionality of the file manage_record.php. The manipulation of the argument id leads to sql injection. The attack may be launched remotely. The identifier of this vulnerability is VDB-220340."
          }
        ],
        "Cvss2": [
          {
            "Source": "cna@vuldb.com",
            "Type": "Secondary",
            "VectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
            "AccessVector": "NETWORK",
            "AccessComplexity": "LOW",
            "Authentication": "SINGLE",
            "ConfidentialityImpact": "PARTIAL",
            "IntegrityImpact": "PARTIAL",
            "AvailabilityImpact": "PARTIAL",
            "BaseScore": 6.5,
            "Severity": "MEDIUM",
            "ExploitabilityScore": 8,
            "ImpactScore": 6.4,
            "ObtainAllPrivilege": false,
            "ObtainUserPrivilege": false,
            "ObtainOtherPrivilege": false,
            "UserInteractionRequired": false
          }
        ],
        "Cvss3": [
          {
            "Source": "nvd@nist.gov",
            "Type": "Primary",
            "VectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
            "AttackVector": "NETWORK",
            "AttackComplexity": "LOW",
            "PrivilegesRequired": "LOW",
            "UserInteraction": "NONE",
            "Scope": "UNCHANGED",
            "ConfidentialityImpact": "HIGH",
            "IntegrityImpact": "HIGH",
            "AvailabilityImpact": "HIGH",
            "BaseScore": 8.8,
            "BaseSeverity": "HIGH",
            "ExploitabilityScore": 2.8,
            "ImpactScore": 5.9
          },
          {
            "Source": "cna@vuldb.com",
            "Type": "Secondary",
            "VectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
            "AttackVector": "NETWORK",
            "AttackComplexity": "LOW",
            "PrivilegesRequired": "LOW",
            "UserInteraction": "NONE",
            "Scope": "UNCHANGED",
            "ConfidentialityImpact": "LOW",
            "IntegrityImpact": "LOW",
            "AvailabilityImpact": "LOW",
            "BaseScore": 6.3,
            "BaseSeverity": "MEDIUM",
            "ExploitabilityScore": 2.8,
            "ImpactScore": 3.4
          }
        ],
        "Cwes": [
          {
            "Source": "cna@vuldb.com",
            "Type": "Primary",
            "CweID": "CWE-89"
          }
        ],
        "Cpes": [
          {
            "URI": "cpe:/a:medical_certificate_generator_app_project:medical_certificate_generator_app:1.0",
            "FormattedString": "cpe:2.3:a:medical_certificate_generator_app_project:medical_certificate_generator_app:1.0:*:*:*:*:*:*:*",
            "WellFormedName": "wfn:[part=\"a\", vendor=\"medical_certificate_generator_app_project\", product=\"medical_certificate_generator_app\", version=\"1\\.0\", update=ANY, edition=ANY, language=ANY, sw_edition=ANY, target_sw=ANY, target_hw=ANY, other=ANY]",
            "Part": "a",
            "Vendor": "medical_certificate_generator_app_project",
            "Product": "medical_certificate_generator_app",
            "Version": "1\\.0",
            "Update": "ANY",
            "Edition": "ANY",
            "Language": "ANY",
            "SoftwareEdition": "ANY",
            "TargetSW": "ANY",
            "TargetHW": "ANY",
            "Other": "ANY",
            "VersionStartExcluding": "",
            "VersionStartIncluding": "",
            "VersionEndExcluding": "",
            "VersionEndIncluding": "",
            "EnvCpes": []
          }
        ],
        "References": [
          {
            "Link": "https://vuldb.com/?ctiid.220340",
            "Source": "cna@vuldb.com",
            "Tags": "Permissions Required,Third Party Advisory",
            "Name": "https://vuldb.com/?ctiid.220340"
          },
          {
            "Link": "https://vuldb.com/?id.220340",
            "Source": "cna@vuldb.com",
            "Tags": "Third Party Advisory",
            "Name": "https://vuldb.com/?id.220340"
          }
        ],
        "Certs": [],
        "PublishedDate": "2023-02-07T10:15:52.61Z",
        "LastModifiedDate": "2023-11-07T04:01:16.2Z",
        "DetectionMethod": ""
      }
    ],
    "Jvns": [],
    "Fortinets": []
  },
  "CVE-2023-2569": {
    "CveID": "CVE-2023-2569",
    "Nvds": [
      {
        "CveID": "CVE-2023-2569",
        "Descriptions": [
          {
            "Lang": "en",
            "Value": "\nA CWE-787: Out-of-Bounds Write vulnerability exists that could cause local denial-of-service,\nelevation of privilege, and potentially kernel execution when a malicious actor with local user\naccess crafts a script/program using an IOCTL call in the Foxboro.sys driver.\n\n"
          }
        ],
        "Cvss2": [],
        "Cvss3": [
          {
            "Source": "nvd@nist.gov",
            "Type": "Primary",
            "VectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
            "AttackVector": "LOCAL",
            "AttackComplexity": "LOW",
            "PrivilegesRequired": "LOW",
            "UserInteraction": "NONE",
            "Scope": "UNCHANGED",
            "ConfidentialityImpact": "HIGH",
            "IntegrityImpact": "HIGH",
            "AvailabilityImpact": "HIGH",
            "BaseScore": 7.8,
            "BaseSeverity": "HIGH",
            "ExploitabilityScore": 1.8,
            "ImpactScore": 5.9
          },
          {
            "Source": "cybersecurity@se.com",
            "Type": "Secondary",
            "VectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
            "AttackVector": "LOCAL",
            "AttackComplexity": "LOW",
            "PrivilegesRequired": "LOW",
            "UserInteraction": "NONE",
            "Scope": "UNCHANGED",
            "ConfidentialityImpact": "HIGH",
            "IntegrityImpact": "HIGH",
            "AvailabilityImpact": "HIGH",
            "BaseScore": 7.8,
            "BaseSeverity": "HIGH",
            "ExploitabilityScore": 1.8,
            "ImpactScore": 5.9
          }
        ],
        "Cwes": [
          {
            "Source": "cybersecurity@se.com",
            "Type": "Primary",
            "CweID": "CWE-787"
          }
        ],
        "Cpes": [
          {
            "URI": "cpe:/a:schneider-electric:ecostruxure_foxboro_dcs_control_core_services:-",
            "FormattedString": "cpe:2.3:a:schneider-electric:ecostruxure_foxboro_dcs_control_core_services:-:*:*:*:*:*:*:*",
            "WellFormedName": "wfn:[part=\"a\", vendor=\"schneider\\-electric\", product=\"ecostruxure_foxboro_dcs_control_core_services\", version=NA, update=ANY, edition=ANY, language=ANY, sw_edition=ANY, target_sw=ANY, target_hw=ANY, other=ANY]",
            "Part": "a",
            "Vendor": "schneider\\-electric",
            "Product": "ecostruxure_foxboro_dcs_control_core_services",
            "Version": "NA",
            "Update": "ANY",
            "Edition": "ANY",
            "Language": "ANY",
            "SoftwareEdition": "ANY",
            "TargetSW": "ANY",
            "TargetHW": "ANY",
            "Other": "ANY",
            "VersionStartExcluding": "",
            "VersionStartIncluding": "",
            "VersionEndExcluding": "",
            "VersionEndIncluding": "",
            "EnvCpes": []
          }
        ],
        "References": [
          {
            "Link": "https://download.schneider-electric.com/files?p_Doc_Ref=SEVD-2023-164-04&p_enDocType=Security+and+Safety+Notice&p_File_Name=SEVD-2023-164-04.pdf",
            "Source": "cybersecurity@se.com",
            "Tags": "Vendor Advisory",
            "Name": "https://download.schneider-electric.com/files?p_Doc_Ref=SEVD-2023-164-04&p_enDocType=Security+and+Safety+Notice&p_File_Name=SEVD-2023-164-04.pdf"
          }
        ],
        "Certs": [],
        "PublishedDate": "2023-06-14T08:15:09.113Z",
        "LastModifiedDate": "2023-06-22T18:06:50.047Z",
        "DetectionMethod": ""
      }
    ],
    "Jvns": [],
    "Fortinets": []
  }
}
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
