### PR TITLE
fix(fetch/fortinet): collect all CPEs

### DIFF
--- a/fetcher/fortinet/fortinet.go
+++ b/fetcher/fortinet/fortinet.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/knqyf263/go-cpe/common"
 	"github.com/knqyf263/go-cpe/naming"
+	"golang.org/x/exp/maps"
 	"golang.org/x/xerrors"
 
 	"github.com/vulsio/go-cve-dictionary/fetcher"
@@ -82,13 +83,17 @@ func convert(a advisory) ([]models.Fortinet, error) {
 		}
 
 		for _, d := range v.Definitions {
+			m := map[models.FortinetCpe]struct{}{}
 			for _, c := range d.Configurations {
 				cpes, err := cpeWalk(c)
 				if err != nil {
 					return nil, xerrors.Errorf("Failed to cpe walk. err: %w", err)
 				}
-				cs.Cpes = cpes
+				for _, cpe := range cpes {
+					m[cpe] = struct{}{}
+				}
 			}
+			cs.Cpes = maps.Keys(m)
 
 			if d.CVSSv3 != nil {
 				parsed := parseCvss3VectorStr(d.CVSSv3.Vector)
@@ -131,7 +136,7 @@ func convert(a advisory) ([]models.Fortinet, error) {
 	return converted, nil
 }
 
-func cpeWalk(conf configurations) ([]models.FortinetCpe, error) {
+func cpeWalk(conf configuration) ([]models.FortinetCpe, error) {
 	cpes := []models.FortinetCpe{}
 
 	for _, n := range conf.Nodes {

--- a/fetcher/fortinet/types.go
+++ b/fetcher/fortinet/types.go
@@ -21,17 +21,17 @@ type vulnerability struct {
 }
 
 type definition struct {
-	Configurations []configurations `json:"configurations"`
-	CVSSv2         *cvss            `json:"cvssv2"`
-	CVSSv3         *cvss            `json:"cvssv3"`
-	CWE            []string         `json:"cwe"`
-	Impact         string           `json:"impact"`
-	ExploitStatus  string           `json:"exploit_status"`
+	Configurations []configuration `json:"configurations"`
+	CVSSv2         *cvss           `json:"cvssv2"`
+	CVSSv3         *cvss           `json:"cvssv3"`
+	CWE            []string        `json:"cwe"`
+	Impact         string          `json:"impact"`
+	ExploitStatus  string          `json:"exploit_status"`
 }
 
-type configurations struct {
-	Nodes    []element       `json:"nodes"`
-	Children *configurations `json:"children"`
+type configuration struct {
+	Nodes    []element      `json:"nodes"`
+	Children *configuration `json:"children"`
 }
 
 type element struct {


### PR DESCRIPTION
# What did you implement:

`go-cve-dictionary fetch fortinet` was not collecting all the CPEs listed in the advisory. 
This PR fixes this bug here.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## before
```console
$ go-cve-dictionary fetch fortinet
$ sqlite3 cve.sqlite3 "SELECT fortinets.advisory_id, fortinets.cve_id,fortinet_cpes.formatted_string, fortinet_cpes.version_start_excluding,fortinet_cpes.version_start_including,fortinet_cpes.version_end_excluding, fortinet_cpes.version_end_including FROM fortinets JOIN fortinet_cpes ON fortinets.id == fortinet_cpes.fortinet_id WHERE fortinets.advisory_id = 'FG-IR-23-001'" | sort
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-100d:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-200c:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-200d:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-300c:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-300c-dc-gen2:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-300c-gen2:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-300c-lenc-gen2:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-3600a:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-40f:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-40f-3g4g:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-40f-3g4g-ea:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-40f-3g4g-jp:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-40f-3g4g-na:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-5001fa2:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-5002fb2:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-50e:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-51e:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-52e:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-60d:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-60d-3g4g-vzw:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-60d-gen2:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-60dh:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-60d-poe:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-620b:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-621b:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigaterugged-100c:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigaterugged-60d:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigaterugged-90d:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-vm01-hyper-v:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-vm01-kvm:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-40f:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-40f-3g4g:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-40f-3g4g-ea:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-40f-3g4g-jp:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-40f-3g4g-na:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-50e:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-50E-2r:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-51e:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-60d:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-60d-3g4g-vzw:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-60d-gen2:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-60d-gen2-j:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-60d-gen2-u:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-60dh:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-60d-i:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-60d-j:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-60d-poe:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-60d-t:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortios-6k7k:*:*:*:*:*:*:*:*||6.0.0||6.0.16
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortios-6k7k:6.2.2:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortios-6k7k:*:*:*:*:*:*:*:*||6.2.6||6.2.7
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortios-6k7k:*:*:*:*:*:*:*:*||6.2.9||6.2.12
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortios-6k7k:6.4.10:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortios-6k7k:6.4.2:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortios-6k7k:6.4.6:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortios-6k7k:6.4.8:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortios-6k7k:7.0.5:*:*:*:*:*:*:*||||
```

## after
```console
$ go-cve-dictionary fetch fortinet
$ sqlite3 cve.sqlite3 "SELECT fortinets.advisory_id, fortinets.cve_id,fortinet_cpes.formatted_string, fortinet_cpes.version_start_excluding,fortinet_cpes.version_start_including,fortinet_cpes.version_end_excluding, fortinet_cpes.version_end_including FROM fortinets JOIN fortinet_cpes ON fortinets.id == fortinet_cpes.fortinet_id WHERE fortinets.advisory_id = 'FG-IR-23-001'" | sort
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-100d:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-200c:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-200d:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-300c:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-300c-dc-gen2:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-300c-gen2:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-300c-lenc-gen2:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-3600a:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-40f:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-40f-3g4g:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-40f-3g4g-ea:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-40f-3g4g-jp:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-40f-3g4g-na:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-5001fa2:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-5002fb2:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-50e:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-51e:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-52e:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-60d:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-60d-3g4g-vzw:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-60d-gen2:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-60dh:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-60d-poe:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-620b:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-621b:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigaterugged-100c:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigaterugged-60d:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigaterugged-90d:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-vm01-hyper-v:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortigate-vm01-kvm:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-40f:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-40f-3g4g:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-40f-3g4g-ea:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-40f-3g4g-jp:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-40f-3g4g-na:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-50e:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-50E-2r:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-51e:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-60d:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-60d-3g4g-vzw:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-60d-gen2:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-60d-gen2-j:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-60d-gen2-u:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-60dh:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-60d-i:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-60d-j:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-60d-poe:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:h:fortinet:fortiwifi-60d-t:-:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortios:*:*:*:*:*:*:*:*||5.0.0||5.6.9
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortios:*:*:*:*:*:*:*:*||6.0.0||6.0.16
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortios:*:*:*:*:*:*:*:*||6.2.0||6.2.12
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortios:*:*:*:*:*:*:*:*||6.4.0||6.4.11
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortios-6k7k:*:*:*:*:*:*:*:*||6.0.0||6.0.16
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortios-6k7k:6.2.2:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortios-6k7k:*:*:*:*:*:*:*:*||6.2.6||6.2.7
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortios-6k7k:*:*:*:*:*:*:*:*||6.2.9||6.2.12
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortios-6k7k:6.4.10:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortios-6k7k:6.4.2:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortios-6k7k:6.4.6:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortios-6k7k:6.4.8:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortios-6k7k:7.0.5:*:*:*:*:*:*:*||||
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortios:*:*:*:*:*:*:*:*||7.0.0||7.0.9
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortios:*:*:*:*:*:*:*:*||7.2.0||7.2.3
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortiproxy:*:*:*:*:*:*:*:*||1.1.0||1.1.6
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortiproxy:*:*:*:*:*:*:*:*||1.2.0||1.2.13
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortiproxy:*:*:*:*:*:*:*:*||2.0.0||2.0.12
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortiproxy:*:*:*:*:*:*:*:*||7.0.0||7.0.8
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortiproxy:*:*:*:*:*:*:*:*||7.2.0||7.2.2
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortiswitchmanager:*:*:*:*:*:*:*:*||7.0.0||7.0.1
FG-IR-23-001|CVE-2023-25610|cpe:2.3:o:fortinet:fortiswitchmanager:*:*:*:*:*:*:*:*||7.2.0||7.2.1
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

