### PR TITLE
feat(commands): Add `cve` command to print a CVE record

### DIFF
--- a/commands/cve.go
+++ b/commands/cve.go
@@ -1,0 +1,88 @@
+package commands
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	db "github.com/vulsio/go-cve-dictionary/db"
+	log "github.com/vulsio/go-cve-dictionary/log"
+	"github.com/vulsio/go-cve-dictionary/models"
+	"golang.org/x/xerrors"
+)
+
+func init() {
+	RootCmd.AddCommand(cveCmd)
+}
+
+var cveCmd = &cobra.Command{
+	Use:   "cve",
+	Short: "Show CVE details",
+	Long:  `Show CVE details`,
+	RunE: func(_ *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return xerrors.Errorf("Usage: go-cve-dictionary cve <CVE-ID>")
+		}
+
+		driver, err := db.NewDB(viper.GetString("dbtype"), viper.GetString("dbpath"), viper.GetBool("debug-sql"), db.Option{})
+		if err != nil {
+			if xerrors.Is(err, db.ErrDBLocked) {
+				return xerrors.Errorf("Failed to open DB. Close DB connection before fetching. err: %w", err)
+			}
+			return xerrors.Errorf("Failed to open DB. err: %w", err)
+		}
+
+		fetchMeta, err := driver.GetFetchMeta()
+		if err != nil {
+			return xerrors.Errorf("Failed to get FetchMeta from DB. err: %w", err)
+		}
+		if fetchMeta.OutDated() {
+			return xerrors.Errorf("Failed to start server. err: SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
+		}
+
+		count := 0
+		nvdCount, err := driver.CountNvd()
+		if err != nil {
+			log.Errorf("Failed to count NVD table: %s", err)
+			return err
+		}
+		count += nvdCount
+
+		jvnCount, err := driver.CountJvn()
+		if err != nil {
+			log.Errorf("Failed to count JVN table: %s", err)
+			return err
+		}
+		count += jvnCount
+
+		fortinetCount, err := driver.CountFortinet()
+		if err != nil {
+			log.Errorf("Failed to count Fortinet table: %s", err)
+			return err
+		}
+		count += fortinetCount
+
+		if count == 0 {
+			log.Infof("No Vulnerability data found. Run the below command to fetch data from NVD, JVN, Fortinet")
+			log.Infof("")
+			log.Infof(" go-cve-dictionary fetch nvd")
+			log.Infof(" go-cve-dictionary fetch jvn")
+			log.Infof(" go-cve-dictionary fetch fortinet")
+			log.Infof("")
+			return nil
+		}
+
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		for _, cveid := range args {
+			cveDetail, err := driver.Get(cveid)
+			if err != nil {
+				return xerrors.Errorf("Error getting CVE details. err: %w", err)
+			}
+			_ = enc.Encode(cveDetail)
+		}
+
+		return nil
+	},
+}


### PR DESCRIPTION
# What did you implement:

The PR implements a cli API for retrieving CVE details:

```
# ./go-cve-dictionary cve CVE-2004-0230
{
  "CveID": "CVE-2004-0230",
  "Nvds": [
    {
      "CveID": "CVE-2004-0230",
      "Descriptions": [
```

It supports a list of CVEs as arguments (prints individual objects):

```
# ./go-cve-dictionary cve CVE-2004-0230 CVE-2005-1119 | jq -s | jq .[].CveID
"CVE-2004-0230"
"CVE-2005-1119"
```

It's reasonably easy to fetch the NVD (or any other DB), but hard to use in scripting jobs as it needs a running server.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES

