### PR TITLE
feat(fetcher/nvd): update reject cve logic

### DIFF
--- a/fetcher/nvd/nvd.go
+++ b/fetcher/nvd/nvd.go
@@ -177,12 +177,13 @@ func convertToModel(cvePath string) (*models.Nvd, error) {
 		return nil, xerrors.Errorf("Failed to decode %s. err: %w", cvePath, err)
 	}
 
+	if item.VulnStatus == "Rejected" {
+		return nil, nil
+	}
+
 	// Description
 	descs := []models.NvdDescription{}
 	for _, desc := range item.Descriptions {
-		if strings.Contains(desc.Value, "** REJECT **") {
-			return nil, nil
-		}
 		descs = append(descs, models.NvdDescription{
 			Lang:  desc.Lang,
 			Value: desc.Value,


### PR DESCRIPTION
# What did you implement:

Previous data feeds did not include a status, but the data feeds we currently use include a status.
Therefore, there is no need to determine the reject status from the description.
https://nvd.nist.gov/vuln/vulnerability-status#divNvdStatus

e.g. 
previous data feed: 
https://github.com/vulsio/vuls-data-raw-nvd-feed-cve/blob/6c059524140e52c3bcfd21b209c83e81450ffafb/2024/CVE-2024-25001.json

https://github.com/vulsio/vuls-data-raw-nvd-feed-cve/blob/6c059524140e52c3bcfd21b209c83e81450ffafb/2024/CVE-2024-35941.json

currently data feeds:
https://github.com/vulsio/vuls-data-raw-nvd-api-cve/blob/acb7222b9e1521aabef89172f54ce02770e2cbe2/2024/CVE-2024-25001.json

https://github.com/vulsio/vuls-data-raw-nvd-api-cve/blob/acb7222b9e1521aabef89172f54ce02770e2cbe2/2024/CVE-2024-35941.json

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
## before
```console
$ go-cve-dictionary fetch nvd 2024
INFO[06-12|12:52:57] Inserting NVD into DB (sqlite3). 
INFO[06-12|12:52:57] Deleting NVD tables... 
INFO[06-12|12:52:57] Fetching CVE information from NVD. 
INFO[06-12|12:52:57] Fetching... https://github.com/vulsio/vuls-data-raw-nvd-api-cve/archive/refs/heads/main.tar.gz 
INFO[06-12|12:53:20] Fetching CVE information from NVD(2024). 
INFO[06-12|12:53:21] Inserting fetched CVEs(2024)... 
13229 / 13229 [-------------------------------------------------------------------------------------] 100.00% 2542 p/s
INFO[06-12|12:53:26] Refreshed 13229 CVEs. 
INFO[06-12|12:53:30] Finished fetching NVD.
$ sqlite3 cve.sqlite3 "SELECT * FROM nvds WHERE nvds.cve_id IN ('CVE-2024-25001', 'CVE-2024-35941')"
11391|CVE-2024-35941|2024-05-19 11:15:49.823+00:00|2024-06-04 13:15:52.613+00:00
```

## after
```console
$ go-cve-dictionary fetch nvd 2024
INFO[06-12|12:47:36] Inserting NVD into DB (sqlite3). 
INFO[06-12|12:47:36] Deleting NVD tables... 
INFO[06-12|12:47:36] Fetching CVE information from NVD. 
INFO[06-12|12:47:40] Fetching... https://github.com/vulsio/vuls-data-raw-nvd-api-cve/archive/refs/heads/main.tar.gz 
INFO[06-12|12:48:03] Fetching CVE information from NVD(2024). 
INFO[06-12|12:48:03] Inserting fetched CVEs(2024)... 
13019 / 13019 [-------------------------------------------------------------------------------------] 100.00% 2219 p/s
INFO[06-12|12:48:09] Refreshed 13019 CVEs. 
INFO[06-12|12:48:14] Finished fetching NVD.
$ sqlite3 cve.sqlite3 "SELECT * FROM nvds WHERE nvds.cve_id IN ('CVE-2024-25001', 'CVE-2024-35941')"
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

