### PR TITLE
feat(log) no progress when --log-json option

### DIFF
--- a/db/rdb.go
+++ b/db/rdb.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"time"
@@ -628,7 +629,12 @@ func deleteJvn(tx *gorm.DB) error {
 }
 
 func insertJvn(tx *gorm.DB, cves []models.Jvn, batchSize int) error {
-	bar := pb.StartNew(len(cves))
+	bar := pb.StartNew(len(cves)).SetWriter(func() io.Writer {
+		if viper.GetBool("log-json") {
+			return io.Discard
+		}
+		return os.Stderr
+	}())
 	for _, cve := range cves {
 		if err := tx.Omit("Cpes").Create(&cve).Error; err != nil {
 			return xerrors.Errorf("Failed to insert. err: %w", err)
@@ -727,7 +733,12 @@ func deleteNvd(tx *gorm.DB) error {
 }
 
 func insertNvd(tx *gorm.DB, cves []models.Nvd, batchSize int) error {
-	bar := pb.StartNew(len(cves))
+	bar := pb.StartNew(len(cves)).SetWriter(func() io.Writer {
+		if viper.GetBool("log-json") {
+			return io.Discard
+		}
+		return os.Stderr
+	}())
 	for _, cve := range cves {
 		if err := tx.Omit("Cpes").Create(&cve).Error; err != nil {
 			return xerrors.Errorf("Failed to insert. err: %w", err)
@@ -782,7 +793,12 @@ func (r *RDBDriver) InsertFortinet(advs []models.Fortinet) (err error) {
 	}
 
 	logger.Infof("Inserting fetched %d CVEs...", len(advs))
-	bar := pb.StartNew(len(advs))
+	bar := pb.StartNew(len(advs)).SetWriter(func() io.Writer {
+		if viper.GetBool("log-json") {
+			return io.Discard
+		}
+		return os.Stderr
+	}())
 	for _, adv := range advs {
 		if err := tx.Omit("Cpes").Create(&adv).Error; err != nil {
 			return xerrors.Errorf("Failed to insert. err: %w", err)
@@ -930,7 +946,12 @@ func deleteMitre(tx *gorm.DB) error {
 }
 
 func insertMitre(tx *gorm.DB, cves []models.Mitre, _ int) error {
-	bar := pb.StartNew(len(cves))
+	bar := pb.StartNew(len(cves)).SetWriter(func() io.Writer {
+		if viper.GetBool("log-json") {
+			return io.Discard
+		}
+		return os.Stderr
+	}())
 	for _, cve := range cves {
 		if err := tx.Create(&cve).Error; err != nil {
 			return xerrors.Errorf("Failed to insert. err: %w", err)

--- a/db/redis.go
+++ b/db/redis.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -443,7 +444,12 @@ func (r *RedisDriver) InsertJvn(years []string) error {
 		delete(uniqCves, year)
 
 		log.Infof("Inserting fetched CVEs(%s)...", year)
-		bar := pb.StartNew(len(cves))
+		bar := pb.StartNew(len(cves)).SetWriter(func() io.Writer {
+			if viper.GetBool("log-json") {
+				return io.Discard
+			}
+			return os.Stderr
+		}())
 		for idx := range chunkSlice(len(cves), batchSize) {
 			pipe := r.conn.Pipeline()
 			for _, cve := range cves[idx.From:idx.To] {
@@ -575,7 +581,12 @@ func (r *RedisDriver) InsertNvd(years []string) error {
 		}
 
 		log.Infof("Inserting fetched CVEs(%s)...", year)
-		bar := pb.StartNew(len(cves))
+		bar := pb.StartNew(len(cves)).SetWriter(func() io.Writer {
+			if viper.GetBool("log-json") {
+				return io.Discard
+			}
+			return os.Stderr
+		}())
 		for idx := range chunkSlice(len(cves), batchSize) {
 			pipe := r.conn.Pipeline()
 			for _, cve := range cves[idx.From:idx.To] {
@@ -681,7 +692,12 @@ func (r *RedisDriver) InsertFortinet(advs []models.Fortinet) error {
 	}
 
 	log.Infof("Inserting fetched %d CVEs...", len(advs))
-	bar := pb.StartNew(len(advs))
+	bar := pb.StartNew(len(advs)).SetWriter(func() io.Writer {
+		if viper.GetBool("log-json") {
+			return io.Discard
+		}
+		return os.Stderr
+	}())
 	for idx := range chunkSlice(len(advs), batchSize) {
 		pipe := r.conn.Pipeline()
 		for _, adv := range advs[idx.From:idx.To] {
@@ -810,7 +826,12 @@ func (r *RedisDriver) InsertMitre(years []string) error {
 		}
 
 		log.Infof("Inserting fetched CVEs(%s)...", year)
-		bar := pb.StartNew(len(cves))
+		bar := pb.StartNew(len(cves)).SetWriter(func() io.Writer {
+			if viper.GetBool("log-json") {
+				return io.Discard
+			}
+			return os.Stderr
+		}())
 		for idx := range chunkSlice(len(cves), batchSize) {
 			pipe := r.conn.Pipeline()
 			for _, cve := range cves[idx.From:idx.To] {


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

no progress when --log-json option

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
## before
```console
$ go-cve-dictionary fetch nvd 2024 --log-json
{"lvl":"info","msg":"Inserting NVD into DB (sqlite3).","t":"2024-07-04T16:11:29.329297881+09:00"}
{"lvl":"info","msg":"Deleting NVD tables...","t":"2024-07-04T16:11:29.32951304+09:00"}
{"lvl":"info","msg":"Fetching CVE information from NVD.","t":"2024-07-04T16:11:29.330988923+09:00"}
{"lvl":"info","msg":"Fetching... https://github.com/vulsio/vuls-data-raw-nvd-api-cve/archive/refs/heads/main.tar.gz","t":"2024-07-04T16:11:29.33107295+09:00"}
{"lvl":"info","msg":"Fetching CVE information from NVD(2024).","t":"2024-07-04T16:11:55.671647674+09:00"}
{"lvl":"info","msg":"Inserting fetched CVEs(2024)...","t":"2024-07-04T16:11:55.796674064+09:00"}
14949 / 14949 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 6748 p/s
{"lvl":"info","msg":"Refreshed 14949 CVEs.","t":"2024-07-04T16:11:58.212097006+09:00"}
{"lvl":"info","msg":"Finished fetching NVD.","t":"2024-07-04T16:12:00.312732832+09:00"}

```

## after
```console
$ go-cve-dictionary fetch nvd 2024 --log-json
{"lvl":"info","msg":"Inserting NVD into DB (sqlite3).","t":"2024-07-04T16:12:42.209739327+09:00"}
{"lvl":"info","msg":"Deleting NVD tables...","t":"2024-07-04T16:12:42.209823522+09:00"}
{"lvl":"info","msg":"Fetching CVE information from NVD.","t":"2024-07-04T16:12:42.226636779+09:00"}
{"lvl":"info","msg":"Fetching... https://github.com/vulsio/vuls-data-raw-nvd-api-cve/archive/refs/heads/main.tar.gz","t":"2024-07-04T16:12:42.226664952+09:00"}
{"lvl":"info","msg":"Fetching CVE information from NVD(2024).","t":"2024-07-04T16:12:54.738655119+09:00"}
{"lvl":"info","msg":"Inserting fetched CVEs(2024)...","t":"2024-07-04T16:12:54.867034135+09:00"}
{"lvl":"info","msg":"Refreshed 14949 CVEs.","t":"2024-07-04T16:12:57.660092576+09:00"}
{"lvl":"info","msg":"Finished fetching NVD.","t":"2024-07-04T16:12:59.588978608+09:00"}

$ go-cve-dictionary fetch nvd 2024
INFO[07-04|16:13:06] Inserting NVD into DB (sqlite3). 
INFO[07-04|16:13:06] Deleting NVD tables... 
INFO[07-04|16:13:06] Fetching CVE information from NVD. 
INFO[07-04|16:13:06] Fetching... https://github.com/vulsio/vuls-data-raw-nvd-api-cve/archive/refs/heads/main.tar.gz 
INFO[07-04|16:13:20] Fetching CVE information from NVD(2024). 
INFO[07-04|16:13:20] Inserting fetched CVEs(2024)... 
14949 / 14949 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 3674 p/s
INFO[07-04|16:13:24] Refreshed 14949 CVEs. 
INFO[07-04|16:13:27] Finished fetching NVD.
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

