### PR TITLE
fix(db/redis): remove CVE key prefix

### DIFF
--- a/db/redis.go
+++ b/db/redis.go
@@ -289,7 +289,9 @@ func (r *RedisDriver) GetCveIDs() ([]string, error) {
 			return nil, xerrors.Errorf("Failed to Scan. err: %w", err)
 		}
 
-		cveIDs = append(cveIDs, keys...)
+		for _, key := range keys {
+			cveIDs = append(cveIDs, strings.TrimPrefix(key, "CVE#CVE#"))
+		}
 
 		if cursor == 0 {
 			break


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

When checking the CVEID in the DB with Redis, the Key Prefix was still attached, so this PR removes it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## before
### SQLite3
```console
$ go-cve-dictionary fetch fortinet
$ go-cve-dictionary search cve
[
  "CVE-2020-6643",
  "CVE-2020-11901",
  "CVE-2022-26122",
  "CVE-2023-47536",
  "CVE-2015-1792",
  "CVE-2017-3730",
  "CVE-2019-15710",
  "CVE-2023-27995",
  "CVE-2023-34988",
  "CVE-2015-3620",
  "CVE-2018-1354",
  ...
```

### Redis
```console
$ docker run --rm --name redis -d -p 127.0.0.1:6379:6379 redis
$ go-cve-dictionary fetch fortinet --dbtype "redis" --dbpath "redis://127.0.0.1:6379"
$ go-cve-dictionary search cve --dbtype "redis" --dbpath "redis://127.0.0.1:6379"
[
  "CVE#CVE#CVE-2017-1000250",
  "CVE#CVE#CVE-2021-24014",
  "CVE#CVE#CVE-2022-29055",
  "CVE#CVE#CVE-2021-36192",
  "CVE#CVE#CVE-2024-55592",
  "CVE#CVE#CVE-2023-23775",
  "CVE#CVE#CVE-2022-42474",
  "CVE#CVE#CVE-2023-45582",
  ...
```

## after
```console
$ docker run --rm --name redis -d -p 127.0.0.1:6379:6379 redis
$ go-cve-dictionary fetch fortinet --dbtype "redis" --dbpath "redis://127.0.0.1:6379"
$ go-cve-dictionary search cve --dbtype "redis" --dbpath "redis://127.0.0.1:6379"
[
  "CVE-2017-1000250",
  "CVE-2021-24014",
  "CVE-2022-29055",
  "CVE-2021-36192",
  "CVE-2024-55592",
  "CVE-2023-23775",
  "CVE-2022-42474",
  "CVE-2023-45582",
  "CVE-2023-44253",
  "CVE-2021-43064",
  ...
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

