### PR TITLE
test(fetcher/cisco): fix test comparison by sorting cisco products

### DIFF
--- a/fetcher/cisco/cisco_test.go
+++ b/fetcher/cisco/cisco_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/vulsio/go-cve-dictionary/models"
 )
@@ -278,7 +279,9 @@ func Test_convert(t *testing.T) {
 					break
 				}
 
-				if diff := cmp.Diff(want, got); diff != "" {
+				if diff := cmp.Diff(want, got, cmpopts.SortSlices(func(a, b models.CiscoProduct) bool {
+					return a.FormattedString < b.FormattedString
+				})); diff != "" {
 					t.Errorf("convert(). (-expected +got):\n%s", diff)
 				}
 			}


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

Cisco products are generated in parallel and the order is not guaranteed, which causes the test to fail as follows:

https://github.com/vulsio/go-cve-dictionary/blob/24d381399187368be6ce9358878b884b89fc9ad4/fetcher/cisco/cisco.go#L191-L243

https://github.com/vulsio/go-cve-dictionary/actions/runs/15774861396/job/44466880874?pr=459

Therefore, when comparing in tests, we sort and compare Cisco products.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## before
```console
$ for i in {1..100}; do go test -count 1 -cover -v ./fetcher/cisco/ -run 'Test_convert/cisco-sa-snmp-dos-sdxnSUcW' 2>&1 >/dev/null; echo $? ; done | sort | uniq -c
     76 0
     24 1
```

## after
```console
$ for i in {1..100}; do go test -count 1 -cover -v ./fetcher/cisco/ -run 'Test_convert/cisco-sa-snmp-dos-sdxnSUcW' 2>&1 >/dev/null; echo $? ; done | sort | uniq -c
    100 0
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

